### PR TITLE
fix debugging on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vitest-explorer",
   "displayName": "Vitest",
   "description": "Run and debug Vitest test cases",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "icon": "img/icon.png",
   "preview": true,
   "author": "zxch3n",

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -125,7 +125,9 @@ async function runTest(
       let windowsPath = file.uri!.fsPath.replace(/\\/g, "/");
       // vscode sends path with lowercase for drive, but tests report with uppercase
       // so there are no matches unless this is adjusted
-      windowsPath = windowsPath.charAt(0).toUpperCase() + windowsPath.slice(1);
+      if(!isDebug) { 
+        windowsPath = windowsPath.charAt(0).toUpperCase() + windowsPath.slice(1);
+      }
       pathToFile.set(windowsPath, file);
     }
   }


### PR DESCRIPTION
Because debugger is running within vscode without using a the powershell shell we need to bypass the drive letter fix while debugging.

This will fix the issue mentiond in #15 