### PR TITLE
File path corrections for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vitest-explorer",
   "displayName": "Vitest",
   "description": "Run and debug Vitest test cases",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "icon": "img/icon.png",
   "preview": true,
   "author": "zxch3n",

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -13,7 +13,9 @@ export function getDebuggerConfig() {}
 let i = 0;
 const suffix = (0 | (Math.random() * 1000000)).toString(36);
 export function getTempPath(): string {
-  return sanitizeFilePath(path.join(tmpdir(), `vitest-report-${suffix}${i++}.json`));
+  return sanitizeFilePath(
+    path.join(tmpdir(), `vitest-report-${suffix}${i++}.json`),
+  );
 }
 
 type Status = "passed" | "failed" | "skipped" | "pending" | "todo" | "disabled";
@@ -77,7 +79,7 @@ export class TestRunner {
     const command = vitestCommand[0];
     const args = [
       ...vitestCommand.slice(1),
-      ...(testFile ? testFile.map(f=> sanitizeFilePath(f)) : []),
+      ...(testFile ? testFile.map((f) => sanitizeFilePath(f)) : []),
       "--reporter=json",
       "--reporter=verbose",
       "--outputFile",
@@ -85,7 +87,7 @@ export class TestRunner {
       "--run",
     ] as string[];
     if (testNamePattern) {
-      args.push("-t", testNamePattern);
+      args.push("-t", '"' + testNamePattern + '"');
     }
 
     const workspacePath = sanitizeFilePath(this.workspacePath);

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -5,14 +5,14 @@ import { existsSync } from "fs";
 import * as path from "path";
 
 import { chunksToLinesAsync } from "@rauschma/stringio";
-import { isWindows } from "./platform";
+import { sanitizeFilePath } from "./utils";
 
 export function getDebuggerConfig() {}
 
 let i = 0;
 const suffix = (0 | (Math.random() * 1000000)).toString(36);
 export function getTempPath(): string {
-  return path.join(tmpdir(), `vitest-report-${suffix}${i++}.json`);
+  return sanitizeFilePath(path.join(tmpdir(), `vitest-report-${suffix}${i++}.json`));
 }
 
 type Status = "passed" | "failed" | "skipped" | "pending" | "todo" | "disabled";
@@ -69,20 +69,14 @@ export class TestRunner {
     log: (msg: string) => void = () => {},
     workspaceEnv: Record<string, string> = {},
     vitestCommand: string[] = this.vitestPath
-      ? isWindows
-        ? ["node", this.vitestPath]
-        : [this.vitestPath]
+      ? [this.vitestPath]
       : ["npx", "vitest"],
   ): Promise<FormattedTestResults> {
-    if (isWindows) {
-      testFile = testFile?.map(adaptWindowsFilePath);
-    }
-
     const path = getTempPath();
     const command = vitestCommand[0];
     const args = [
       ...vitestCommand.slice(1),
-      ...(testFile ? testFile : []),
+      ...(testFile ? testFile.map(f=> sanitizeFilePath(f)) : []),
       "--reporter=json",
       "--reporter=verbose",
       "--outputFile",
@@ -93,7 +87,7 @@ export class TestRunner {
       args.push("-t", testNamePattern);
     }
 
-    const workspacePath = this.workspacePath;
+    const workspacePath = sanitizeFilePath(this.workspacePath);
     let error: any;
     let outputs: string[] = [];
     const env = { ...process.env, ...workspaceEnv };
@@ -101,9 +95,7 @@ export class TestRunner {
       // it will throw when test failed or the testing is failed to run
       const child = spawn(command, args, {
         cwd: workspacePath,
-        stdio: ["ignore", "pipe", "pipe"],
-        env,
-        shell: isWindows ? "powershell" : false,
+        shell: true,
       });
 
       for await (const line of chunksToLinesAsync(child.stdout)) {
@@ -114,13 +106,11 @@ export class TestRunner {
       error = e;
     }
 
-    const pathCleaned = isWindows? path.replace(/\\/g, "/"): path;
-
-    if (!existsSync(pathCleaned)) {
+    if (!existsSync(path)) {
       await handleError();
     }
 
-    const file = await readFile(pathCleaned, "utf-8");
+    const file = await readFile(path, "utf-8");
 
     const out = JSON.parse(file) as FormattedTestResults;
     if (out.testResults.length === 0) {
@@ -163,12 +153,4 @@ export async function getNodeVersion() {
   for await (const line of chunksToLinesAsync(process.stdout)) {
     return line;
   }
-}
-
-export function adaptWindowsFilePath(path: string) {
-  if (!isWindows) {
-    return path;
-  }
-
-  return path.replace(/\\/g, "/").replace(/^\w:/, "");
 }

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 
 import { chunksToLinesAsync } from "@rauschma/stringio";
 import { sanitizeFilePath } from "./utils";
+import { isWindows } from "./platform";
 
 export function getDebuggerConfig() {}
 
@@ -95,7 +96,9 @@ export class TestRunner {
       // it will throw when test failed or the testing is failed to run
       const child = spawn(command, args, {
         cwd: workspacePath,
-        shell: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env,
+        shell: isWindows,
       });
 
       for await (const line of chunksToLinesAsync(child.stdout)) {

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -87,7 +87,11 @@ export class TestRunner {
       "--run",
     ] as string[];
     if (testNamePattern) {
-      args.push("-t", `"${testNamePattern}"`);
+      if (isWindows) {
+        args.push("-t", `"${testNamePattern}"`);
+      } else {
+        args.push("-t", testNamePattern);
+      }
     }
 
     const workspacePath = sanitizeFilePath(this.workspacePath);

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -87,7 +87,7 @@ export class TestRunner {
       "--run",
     ] as string[];
     if (testNamePattern) {
-      args.push("-t", '"' + testNamePattern + '"');
+      args.push("-t", `"${testNamePattern}"`);
     }
 
     const workspacePath = sanitizeFilePath(this.workspacePath);

--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -11,13 +11,13 @@ export function getVitestPath(projectRoot: string): string | undefined {
   }
 
   if (existsSync(path.resolve(node_modules, "vitest", "vitest.mjs"))) {
-    return path.resolve(node_modules, "vitest", "vitest.mjs");
+    return sanitizeFilePath(path.resolve(node_modules, "vitest", "vitest.mjs"));
   }
 
   const suffixes = [".js", "", ".cmd"];
   for (const suffix of suffixes) {
     if (existsSync(path.resolve(node_modules, ".bin", "vitest" + suffix))) {
-      return path.resolve(node_modules, ".bin", "vitest" + suffix);
+      return sanitizeFilePath(path.resolve(node_modules, ".bin", "vitest" + suffix));
     }
   }
 

--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -47,3 +47,14 @@ export async function getVitestVersion(vitestPath?: string): Promise<string> {
 
   throw new Error(`Cannot get vitest version from "${vitestPath}"`);
 }
+
+const capitalizeFirstLetter = (string:string)=> string.charAt(0).toUpperCase() + string.slice(1);
+
+const replaceDoubleSlashes = (string:string)=> string.replace(/\\/g, "/");
+
+export function sanitizeFilePath(path: string) {
+  if(isWindows) {
+  return capitalizeFirstLetter(replaceDoubleSlashes(path));
+  }
+  return path;
+}

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -1,12 +1,11 @@
 import * as vscode from "vscode";
 import {
-  adaptWindowsFilePath,
   FormattedTestResults,
   getNodeVersion,
   getTempPath,
   TestRunner,
 } from "./pure/runner";
-import { getVitestPath as getVitestPath } from "./pure/utils";
+import { sanitizeFilePath, getVitestPath } from "./pure/utils";
 import {
   getAllTestCases,
   getTestCaseId,
@@ -16,7 +15,6 @@ import {
 import { getConfig } from "./config";
 import { readFile } from "fs-extra";
 import { existsSync } from "fs";
-import { isWindows } from "./pure/platform";
 
 export async function runHandler(
   ctrl: vscode.TestController,
@@ -120,16 +118,7 @@ async function runTest(
 
   const pathToFile = new Map<string, vscode.TestItem>();
   for (const file of fileItems) {
-    pathToFile.set(file.uri!.fsPath, file);
-    if (isWindows) {
-      let windowsPath = file.uri!.fsPath.replace(/\\/g, "/");
-      // vscode sends path with lowercase for drive, but tests report with uppercase
-      // so there are no matches unless this is adjusted
-      if(!isDebug) { 
-        windowsPath = windowsPath.charAt(0).toUpperCase() + windowsPath.slice(1);
-      }
-      pathToFile.set(windowsPath, file);
-    }
+    pathToFile.set(sanitizeFilePath(file.uri!.fsPath), file);
   }
 
   let out;
@@ -243,7 +232,7 @@ async function debugTest(
   const testData = testItems.map((item) => WEAKMAP_TEST_DATA.get(item)!);
   config.args = [
     "run",
-    ...new Set(testData.map((x) => x.getFilePath()).map(adaptWindowsFilePath)),
+    ...new Set(testData.map((x) => x.getFilePath())),
     testData.length === 1 ? "--testNamePattern" : "",
     testData.length === 1 ? testData[0].getFullPattern() : "",
     "--reporter=default",


### PR DESCRIPTION
I have not found that the latest updates have helped, but I did find that the path issues identified by @AlmarAubel are the issue. These changes make a single path sanitization function which has solved the issues for `runTest()` (normal) on my Windows 10 machine.

#### I have still been unable to run/fix the `debugTest()` (debug) for my windows machine