### PR TITLE
Feature suggestion. Add failure notification using vscode message. Optional using extension setting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,12 @@
           ],
           "default": null,
           "scope": "machine"
+        },
+        "vitest.showFailMessages": {
+          "description": "Get instant feedback when using Watch Mode. Pop-ups an error when a test fails.",
+          "type": "boolean",
+          "scope": "resource",
+          "default": false
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,5 +9,6 @@ export function getConfig() {
     include: config.get('include') as string[],
     exclude: config.get('exclude') as string[],
     enable: config.get('enable') as boolean,
+    showFailMessages: config.get('showFailMessages') as boolean,
   }
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -9,6 +9,7 @@ import type { ErrorWithDiff, File, Task } from 'vitest'
 import type { TestController, TestItem, TestRun } from 'vscode'
 import { Disposable, Location, Position, TestMessage, TestRunRequest, Uri, workspace } from 'vscode'
 import { Lock } from 'mighty-promise'
+import * as vscode from 'vscode'
 import { getConfig } from './config'
 import type { TestFileDiscoverer } from './discover'
 import { execWithLog } from './pure/utils'
@@ -176,6 +177,8 @@ export class TestWatcher extends Disposable {
     }
 
     this.testStatus.value = { passed, failed, skipped }
+    if (getConfig().showFailMessages && failed > 0)
+      vscode.window.showErrorMessage(`Vitest: You have ${failed} failing Unit Test(s).`)
   }
 
   public runTests(tests?: readonly TestItem[]) {


### PR DESCRIPTION
I like the Watch Mode for Vitest and thought it would be a nice feature if when making changes you got an immediate pop-up on a test failure, so you know the change that broke it. I made the pop-up an optional  boolean setting.

<img width="805" alt="Screen Shot 2022-05-23 at 3 01 55 PM" src="https://user-images.githubusercontent.com/14003647/169888748-84030d4b-3ef6-44ba-8cc9-bcfa1812801e.png">

