### PR TITLE
handle the case where the command starts with a lower case driver letter

### DIFF
--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -89,7 +89,7 @@ export class TestRunner {
     const outputs: string[] = []
     const env = { ...process.env, ...workspaceEnv }
     let testResultFiles = [] as File[]
-    const output = await runVitestWithApi({ cmd: command, args }, this.workspacePath, {
+    const output = await runVitestWithApi({ cmd: sanitizeFilePath(command), args }, this.workspacePath, {
       log: (line) => {
         log.info(`${filterColorFormatOutput(line.trimEnd())}\r\n`)
         outputs.push(filterColorFormatOutput(line))


### PR DESCRIPTION
When running tests on my machine, I got errors saying:

> Test result not found.
> Are there tests with the same name?
> ...

The issue is that [Uri.fsPath](https://code.visualstudio.com/api/references/vscode-api#Uri) returns a lower case drive letter instead of an upper case drive letter.

As a result, we give vitest a bad command and its internal filter will discard the test file.
Hence giving me the above error.

This PR solved the issue for me.
However, there might be a better place to put the call to sanitizeFilePath()
