### PR TITLE
feat: add `additionalDebugConfiguration` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   `[\"**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}\"]`
 - `vitest.exclude`: Exclude globs for test files. Default:
   `[\"**/node_modules/**\", \"**/dist/**\", \"**/cypress/**\", \"**/.{idea,git,cache,output,temp}/**\"]`
+- `vitest.additionalDebugConfiguration`: Properties overlayed onto the run configuration to launch the vitest for debugging. For example: `{"trace": true}`
 
 # Screenshots
 

--- a/package.json
+++ b/package.json
@@ -132,6 +132,12 @@
           "type": "array",
           "scope": "resource",
           "default": []
+        },
+        "vitest.additionalDebugConfiguration": {
+          "markdownDescription": "Properties overlayed onto the run configuration to launch the vitest for debugging. For example: `{\"trace\": true}`",
+          "type": "object",
+          "scope": "resource",
+          "default": {}
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export function getConfig(workspaceFolder?: WorkspaceFolder | vscode.Uri | strin
     include: get<string[]>('include', []),
     exclude: get<string[]>('exclude', []),
     enable: get<boolean>('enable', false),
+    additionalDebugConfiguration: get<Partial<vscode.DebugConfiguration>>('additionalDebugConfiguration', {})
   }
 }
 

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -292,6 +292,7 @@ async function runTest(
         args,
         smartStep: true,
         env: cfg.env,
+        ...(getConfig(workspaceFolder).additionalDebugConfiguration)
       }).then(() => {
         log('Debugging started')
       }, (err) => {


### PR DESCRIPTION
As per the modification to README.md:

> - `vitest.additionalDebugConfiguration`: Properties overlayed onto the run configuration to launch the vitest for debugging. For example: `{"trace": true}`
