### PR TITLE
feat: Changing the background color of StatusBarItem 

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,13 @@
           "scope": "window",
           "default": false
         },
+        "vitest.changeBackgroundColor": {
+          "description": "Change background color of status bar item on failing tests.",
+          "type": "boolean",
+          "scope": "window",
+          "default": true
+
+        },
         "vitest.disabledWorkspaceFolders": {
           "description": "Disabled workspace folders names in multiroot environment",
           "type": "array",

--- a/src/StatusBarItem.ts
+++ b/src/StatusBarItem.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import { Command } from './command'
+import { getRootConfig } from './config'
 
 export class StatusBarItem extends vscode.Disposable {
   public item = vscode.window.createStatusBarItem(
@@ -19,6 +20,7 @@ export class StatusBarItem extends vscode.Disposable {
     this.item.command = Command.StartWatching
     this.item.text = '$(test-view-icon) Vitest'
     this.item.tooltip = 'Click to start watch mode'
+    this.setBackgroundColor(false)
     this.item.show()
   }
 
@@ -39,6 +41,7 @@ export class StatusBarItem extends vscode.Disposable {
       (passed / total * 100).toFixed(0)
     }%, ${skipped} skipped)`
     this.item.tooltip = 'Vitest is watching. Click to stop.'
+    this.setBackgroundColor(failed > 0)
     this.item.show()
   }
 
@@ -46,6 +49,12 @@ export class StatusBarItem extends vscode.Disposable {
     this.item.command = Command.StopWatching
     this.item.text = '$(loading~spin) Vitest is running'
     this.item.tooltip = 'Click to stop watching'
+    this.setBackgroundColor(false)
     this.item.show()
+  }
+
+  setBackgroundColor(failedTests: Boolean) {
+    if (getRootConfig().changeBackgroundColor)
+      this.item.backgroundColor = failedTests ? new vscode.ThemeColor('statusBarItem.errorBackground') : undefined
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ export function getRootConfig() {
 
   return {
     showFailMessages: rootConfig.get('showFailMessages', false),
+    changeBackgroundColor: rootConfig.get('changeBackgroundColor', true),
     disabledWorkspaceFolders: rootConfig.get<string[]>('disabledWorkspaceFolders', []),
   }
 }


### PR DESCRIPTION
Awesome extension @zxch3n!

Added a small tweak to change the background color of StatusBarItem to "errorBackground" when some tests are failing. An optional setting, true by default.

Of course open to feedback :) 