### PR TITLE
Vite 3 migration

### DIFF
--- a/src/pure/ApiProcess.ts
+++ b/src/pure/ApiProcess.ts
@@ -94,7 +94,7 @@ export class ApiProcess {
     else {
       this.customStartProcess({
         cmd: this.vitest.cmd,
-        args: [...this.vitest.args, '--api', port.toString()],
+        args: [...this.vitest.args, '--api.port', port.toString()],
         cfg: {
           cwd,
           env: { ...process.env, ...getConfig(this.workspace).env },
@@ -135,7 +135,7 @@ export class ApiProcess {
   private _start(debouncedLog: (line: string) => void, port: number, cwd: string) {
     this.process = execWithLog(
       this.vitest.cmd,
-      [...this.vitest.args, '--api', port.toString()],
+      [...this.vitest.args, '--api.port', port.toString()],
       {
         cwd,
         env: { ...process.env, ...getConfig(this.workspace).env },

--- a/src/pure/ApiProcess.ts
+++ b/src/pure/ApiProcess.ts
@@ -94,7 +94,7 @@ export class ApiProcess {
     else {
       this.customStartProcess({
         cmd: this.vitest.cmd,
-        args: [...this.vitest.args, '--api.port', port.toString()],
+        args: [...this.vitest.args, '--api.port', port.toString(), '--api.host', '127.0.0.1'],
         cfg: {
           cwd,
           env: { ...process.env, ...getConfig(this.workspace).env },
@@ -135,7 +135,7 @@ export class ApiProcess {
   private _start(debouncedLog: (line: string) => void, port: number, cwd: string) {
     this.process = execWithLog(
       this.vitest.cmd,
-      [...this.vitest.args, '--api.port', port.toString()],
+      [...this.vitest.args, '--api.port', port.toString(), '--api.host', '127.0.0.1'],
       {
         cwd,
         env: { ...process.env, ...getConfig(this.workspace).env },

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -78,7 +78,7 @@ export class TestRunner {
       args.push('--update')
 
     if (testNamePattern)
-      args.push('-t', testNamePattern)
+      args.push('-t', testNamePattern.replace(/[$^+?()[\]]/g, '\\$&'))
 
     const workspacePath = sanitizeFilePath(this.workspacePath)
     const outputs: string[] = []

--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -131,7 +131,7 @@ const replaceDoubleSlashes = (string: string) => string.replace(/\\/g, '/')
 
 export function sanitizeFilePath(path: string) {
   if (isWindows)
-    return capitalizeFirstLetter(replaceDoubleSlashes(path))
+    return replaceDoubleSlashes(path)
 
   return path
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -71,7 +71,7 @@ export class TestWatcher extends Disposable {
       let timer: any
       this.process = execWithLog(
         this.vitest.cmd,
-        [...this.vitest.args, '--api', port.toString()],
+        [...this.vitest.args, '--api.port', port.toString()],
         {
           cwd: this.workspace.uri.fsPath,
           env: { ...process.env, ...getConfig(this.workspace).env },

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -71,7 +71,7 @@ export class TestWatcher extends Disposable {
       let timer: any
       this.process = execWithLog(
         this.vitest.cmd,
-        [...this.vitest.args, '--api.port', port.toString()],
+        [...this.vitest.args, '--api.port', port.toString(), '--api.host', '127.0.0.1'],
         {
           cwd: this.workspace.uri.fsPath,
           env: { ...process.env, ...getConfig(this.workspace).env },


### PR DESCRIPTION
Various changes to migrate to Vite 3.0. Only tested on Windows 11.

- Use --api.port instead of --api.
- Bind to 127.0.0.1 instead of localhost ([breaking change](https://github.com/vitejs/vite/commit/49c0896))
- Fix parsing error by escaping special characters in test names (e.g., `"add 1 + 1"` => `"add 1 \+ 1"`)
- Stop capitalizing the first character of the test file path name. I'm not entirely sure why this was being done originally, but it was creating a mismatch with the way vitest was gathering the test file names. Vitest does a simple case-sensitive `.includes()` check, so `c:\` was not matching the `C:\` in the paths that vitest is producing. [This case-sensitive matching](https://github.com/vitest-dev/vitest/blob/9dbe4e4af7e580ebe33efe243d4137460014f3e4/packages/vitest/src/node/core.ts#L511) was breaking the "Debug Test" feature.