### PR TITLE
fix wrong output.

### DIFF
--- a/src/pure/ApiProcess.ts
+++ b/src/pure/ApiProcess.ts
@@ -84,7 +84,7 @@ export class ApiProcess {
 
       clearTimeout(timer)
       timer = setTimeout(() => {
-        _log(logs.join('\r\n'))
+        _log(logs.join(''))
         logs.length = 0
       }, 200)
     }


### PR DESCRIPTION
The output of the program comes with newlines, there is no need to add newlines to log.
![image](https://user-images.githubusercontent.com/27798227/205651463-aae7af47-a1f9-46d2-8813-171e46147da2.png)

Before:
![image](https://user-images.githubusercontent.com/27798227/205651413-de2d5bee-7ef3-4d59-86bd-5a728c89131f.png)
After:
![image](https://user-images.githubusercontent.com/27798227/205651360-719a132e-22ba-4300-be91-c1491d5f8a01.png)
