### PR TITLE
fix: tests still say Running after test run finishes

### DIFF
--- a/src/pure/ApiProcess.ts
+++ b/src/pure/ApiProcess.ts
@@ -119,8 +119,9 @@ export class ApiProcess {
       this.vitestState = buildWatchClient({
         port,
         handlers: this.handlers,
-        reconnectInterval: 100,
-        reconnectTries: 10,
+        // vitest could take up to 10 seconds to start up on some computers, so reconnects need to be long enough to handle that
+        reconnectInterval: 500,
+        reconnectTries: 20,
       })
 
       this.vitestState.loadingPromise.then((isRunning) => {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -139,8 +139,9 @@ export class TestWatcher extends Disposable {
             }
           },
         },
-        reconnectInterval: 200,
-        reconnectTries: 10,
+        // vitest could take up to 10 seconds to start up on some computers, so reconnects need to be long enough to handle that
+        reconnectInterval: 500,
+        reconnectTries: 20,
       })
 
       effect(() => {


### PR DESCRIPTION
Was only waiting a second for vitest to start up before giving up looking for results, which is too short for slower computers. This extends it to wait up to 10 seconds, still short of the original default of 20 seconds. This likely fixes some of the issues reported in #98.

Not addressed here is the issue of no feedback if the client fails to connect, that functionality appears to be missing from vitest's client.