### PR TITLE
fix: unable to cancel in-progress test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "mocha": "^9.2.1",
     "prettier": "^2.5.1",
     "semver": "^7.3.5",
+    "tree-kill": "^1.2.2",
     "tsup": "^5.12.7",
     "typescript": "^4.5.5",
     "vite": "^2.8.6",

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -2,6 +2,7 @@ import { spawn } from 'child_process'
 
 import { chunksToLinesAsync } from '@rauschma/stringio'
 import type { File } from 'vitest'
+import type { CancellationToken } from 'vscode'
 import {
   filterColorFormatOutput,
   sanitizeFilePath,
@@ -68,6 +69,7 @@ export class TestRunner {
     updateSnapshot = false,
     onUpdate?: (files: File[]) => void,
     customStartProcess?: (config: StartConfig) => void,
+    cancellation?: CancellationToken,
   ): Promise<{ testResultFiles: File[]; output: string }> {
     const command = vitestCommand.cmd
     const args = [
@@ -91,7 +93,8 @@ export class TestRunner {
       },
       onFinished: (files) => {
         if (files == null) {
-          handleError()
+          if (!cancellation?.isCancellationRequested)
+            handleError()
           return
         }
 
@@ -101,7 +104,7 @@ export class TestRunner {
         files && onUpdate && onUpdate(files)
       },
       onUpdate,
-    }, customStartProcess)
+    }, customStartProcess, cancellation)
 
     return { testResultFiles, output }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,7 +2990,7 @@ tr46@^1.0.1:
 
 tree-kill@^1.2.2:
   version "1.2.2"
-  resolved "https://registry.npmmirror.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 ts-interface-checker@^0.1.9:


### PR DESCRIPTION
Resolves #109.

Also fixes an issue on Windows where the vitest process was never properly terminated, creating a new node.exe process every test run. `process.kill` doesn't work when `shell: true` is sent to spawn, which is the case on Windows.