### PR TITLE
fix: read package.json to check if a folder is a Vitest env

### DIFF
--- a/src/pure/isVitestEnv.ts
+++ b/src/pure/isVitestEnv.ts
@@ -53,8 +53,8 @@ export async function mayBeVitestEnv(projectRoot: string | WorkspaceFolder): Pro
     return false
 
   const pkgPath = path.join(projectRoot, 'package.json') as string
-  const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as any
-  if (existsSync(pkg)) {
+  if (existsSync(pkgPath)) {
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as any
     if (pkg.devDependencies && pkg.devDependencies.vitest)
       return true
 


### PR DESCRIPTION
The code that checks `package.json` to see if Vitest is in the repo is currently not working.

Instead of checking whether the `package.json` file exists on disk, and then reading it, it always reads the file and then check if the content is a valid path.

This have the effect that if a folder uses Vite but not Vitest, it would be recognised as a Vitest folder. This is because checking the `package.json` wouldn't happen, and we would default to checking for the presence of `vite.config.(j|t)s` which would exists in this case.