### PR TITLE
Fix Vitest not starting up due to failed version check on windows #88

### DIFF
--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -92,7 +92,7 @@ export async function getVitestVersion(
     })
   }
   else {
-    child = spawn(vitestCommand.cmd, [...vitestCommand.args, '-v'], {
+    child = spawn(process.execPath, [vitestCommand.cmd, ...vitestCommand.args, '-v'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, ...env },
     })


### PR DESCRIPTION
This PR is a fix for [#88 Vitest not starting up due to failed version check on windows](https://github.com/vitest-dev/vscode/issues/88)

When node is installed via a version manager like `n` or `nvm`, `spawn` fails `"env: node: No such file or directory".

I've added the `process.execPath` argument to the `spawn` command as recommended in https://github.com/electron/electron/issues/3627#issuecomment-793052457.

This issue is not limited to Windows, it affects macOS as well.