### PR TITLE
feat: make skipFiles of launch config configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
   `[\"**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}\"]`
 - `vitest.exclude`: Exclude globs for test files. Default:
   `[\"**/node_modules/**\", \"**/dist/**\", \"**/cypress/**\", \"**/.{idea,git,cache,output,temp}/**\"]`
+- `vitest.debugExclude`: Automatically skip files covered by these glob patterns. Default:
+  `[\"<node_internals>/**\", \"**/node_modules/**\"]`
 
 # Screenshots
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,15 @@
           ],
           "scope": "resource"
         },
+        "vitest.debugExclude": {
+          "markdownDescription": "Automatically skip files covered by these glob patterns. \nDefault: `[\"<node_internals>/**\", \"**/node_modules/**\"]`",
+          "type": "array",
+          "default": [
+            "<node_internals>/**",
+            "**/node_modules/**"
+          ],
+          "scope": "resource"
+        },
         "vitest.nodeEnv": {
           "markdownDescription": "The env passed to runner process in addition to `process.env`",
           "type": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export function getConfig(workspaceFolder?: WorkspaceFolder | vscode.Uri | strin
     include: get<string[]>('include', []),
     exclude: get<string[]>('exclude', []),
     enable: get<boolean>('enable', false),
+    debugExclude: get<string[]>('debugExclude', []),
   }
 }
 

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -285,7 +285,7 @@ async function runTest(
         request: 'launch',
         name: 'Debug Current Test File',
         autoAttachChildProcesses: true,
-        skipFiles: ['<node_internals>/**', '**/node_modules/**'],
+        skipFiles: config.debugExclude,
         program: getVitestPath(workspaceFolder.uri.fsPath),
         args,
         smartStep: true,


### PR DESCRIPTION
The launch configuration used for attaching the debugger sets `skipFiles` to `["<node_internals>/**", "**/node_modules/**"]` to make sure you are only debugging your own code. We experienced issues with the debugger being extremely slow to hit the first breakpoint. Experienced the same behaviour if we used this config with Jest. Setting it to an empty array resolved the issue for us.
Sometimes we also want to debug the `node_modules` so I made this configurable via the `debugExclude` setting, defaults to `["<node_internals>/**", "**/node_modules/**"]`. 