### PR TITLE
fix: Add better version detection

### DIFF
--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { spawnVitestVersion } from '../src/pure/utils'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// Mock vscode ("pure" modules aren't quite pure)
+vi.mock('vscode', () => {
+  return {
+    default: { myDefaultKey: vi.fn() },
+    namedExport: vi.fn(),
+    window: {
+      createOutputChannel: () => {
+        return {
+          appendLine: vi.fn(),
+        }
+      },
+    },
+  }
+})
+
+describe('utils', () => {
+  describe('spawnVitestVersion', () => {
+    it('should return undefined when passing an unkown command', async () => {
+      const result = await spawnVitestVersion('unknown-command', ['xxx'], {})
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when the commmand don\'t return any version', async () => {
+      const result = await spawnVitestVersion('/bin/ls', ['-l'], {})
+      expect(result).toBeUndefined()
+    })
+  })
+
+  // TODO mock spawn
+  // describe('xxx', () => {
+  //   const spy = vi.mock('childProcess', 'spawnSync', (a, b) => vi.fn())
+
+  //   it('should return the version when the command return a version', async () => {
+  //     await expect(() => tryBoth('xxx', ['a', 'b'], { one: '1', two: '2' })).rejects.toThrowError('xx')
+
+  //     expect(spy).toHaveBeenCalledTimes(2)
+  //   })
+  // })
+})


### PR DESCRIPTION
This is a follow-up PR for #118 which have broken some installs:
- https://github.com/vitest-dev/vscode/issues/88#issuecomment-1398074211

It seems to fix:
- https://github.com/vitest-dev/vscode/issues/124
- https://github.com/vitest-dev/vscode/issues/124
- https://github.com/vitest-dev/vscode/issues/90
- https://github.com/vitest-dev/vscode/issues/131

and probably:
- https://github.com/vitest-dev/vscode/issues/13

In some cases, vitest need to be started using `spawn(vitestCommand.cmd, [...vitestCommand.args, '-v'], envs))`, and in other by using `spawn(process.execPath, [vitestCommand.cmd, ...vitestCommand.args, '-v'], envs))`.

There are lot of OS / Node install combinations, and I don't have a clear picture of which to use and when.

The easiest fix that I could find, was to try both commands and see which one worked.

It's not the cleanest solution, but I'm open to suggestions :)