### PR TITLE
fix: spawn() requires a command name, not a full path

### DIFF
--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -93,7 +93,8 @@ export const spawnVitestVersion = async (
 ): Promise<string | undefined> => {
   log.info(`Trying to get vitest version from ${command} ${args.join(' ')}...`)
 
-  const child = spawn(command, args, {
+  const child = spawn(path.basename(command), args, {
+    cwd: path.dirname(command),
     stdio: ['ignore', 'pipe', 'pipe'],
     env,
   })


### PR DESCRIPTION
In my environment my projects are stored in a folder that contains space. Because of this when using this extension it is not possible to identify the installed vitest version.

In my case, my projects are located in `D:/my projects/...`, for example. Meanwhile, version checking takes place via `spawn()` and the entire path to `vitest.cmd` (on Windows, for example) is passed as the first argument:

```js
spawn("D:/my projects/example/node_modules/.bin/vitest.cmd"); // ...
```

However, this is not possible in Node, as the first parameter of `spawn()` essentially needs to be the name of the command (in this case, just `vitest.cmd`), and the path to it must be presented as an option ` cwd`.

I made a small modification during the `spawn()` process so that the command is separated from the path, and correctly sent to the function. So everything should work as expected.

Before:

```
[INFO 9:31:29 PM] Trying to get vitest version from d:\my projects\example\node_modules\.bin\vitest.cmd -v...
[INFO 9:31:29 PM] Trying to get vitest version from C:\Users\david\AppData\Local\Programs\Microsoft VS Code\Code.exe d:\my projects\example\node_modules\.bin\vitest.cmd -v...
[INFO 9:31:29 PM] Error: Cannot get vitest version. Please open an issue at https://github.com/vitest-dev/vscode/issues and join the logs above.
```

Now:

```
[INFO 9:32:49 PM] Trying to get vitest version from d:\my projects\example\node_modules\.bin\vitest.cmd -v...
[INFO 9:32:49 PM] vitest/0.12.6 win32-x64 node-v19.2.0

[INFO 9:32:49 PM] Vitest Workspace [basic]: Vitest version = 0.12.6
```

References:

- https://stackoverflow.com/questions/21356372/node-child-process-spawn-not-working-with-spaces-in-path-on-windows
- https://stackoverflow.com/a/30893153/755393