### PR TITLE
bug: discoverAllTestFilesInWorkspace uses path.relative like watchAll…

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -103,6 +103,7 @@ export class TestFileDiscoverer extends vscode.Disposable {
 
     await Promise.all(
       vscode.workspace.workspaceFolders.map(async (workspaceFolder) => {
+        const workspacePath = workspaceFolder.uri.fsPath
         const exclude = getConfig(workspaceFolder).exclude
         for (const include of getConfig(workspaceFolder).include) {
           const pattern = new vscode.RelativePattern(
@@ -110,7 +111,7 @@ export class TestFileDiscoverer extends vscode.Disposable {
             include,
           )
           const filter = (v: vscode.Uri) =>
-            exclude.every(x => !minimatch(v.fsPath, x, { dot: true }))
+            exclude.every(x => !minimatch(path.relative(workspacePath, v.fsPath), x, { dot: true }))
 
           for (const file of await vscode.workspace.findFiles(pattern)) {
             filter(file)


### PR DESCRIPTION
It is similar to issue #60 

<img width="1400" alt="vitest config exclude" src="https://github.com/vitest-dev/vscode/assets/13225610/7dc1bdbd-5d4e-4e39-b6ac-1e1fc17bd9a4">


It looks like the `discoverAllTestFilesInWorkspace` and `watchAllTestFilesInWorkspace`
handle different for `vitest.config`'s `exclude`
1. not familiar with the code (no typescript)
2. need to get a testcase, not sure  if there is one for `watchAllTestFilesInWorkspace` testcase.
3. like the main author review it.

thank you for making vitest 👍 !

