### PR TITLE
Fix first-run and unsaved test runs

### DIFF
--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -327,7 +327,12 @@ async function runTest(
   syncFilesTestStatus(testResultFiles, discover, ctrl, run, true, false, finishedTests)
   if (mode !== 'debug' && !cancellation?.isCancellationRequested) {
     for (const item of testCaseSet) {
-      if (!finishedTests.has(item)) {
+      let testFinished = false
+      for (const finishedItem of finishedTests) {
+        if (finishedItem.id === item.id)
+          testFinished = true
+      }
+      if (!testFinished) {
         run.errored(item, new vscode.TestMessage(`${TEST_NOT_FOUND_MESSAGE}\r\n\r\nVitest output:\r\n${filterColorFormatOutput(output)}`))
         log.error(`Test not found: ${item.id}`)
       }


### PR DESCRIPTION
## Done

By the time the tests have completed the TestItem reference has changed (I tried to track this down to see if there was an upstream issue that could be resolved, but couldn't identify where this was happening) so this PR updates the finished test check to use the test item's ID instead of the reference.

Before this fix the tests were given the green tick but then immediately afterwards the `run.errored()` call failed the test.

Fixes: #159.

## QA

- Run this branch in the development window (F5).
- Open a test file and run a single test.
- The test should complete and there should be no error about missing test results.
- Modify the test (e.g. change the expected value) but DON'T save the file.
- Run the test you modified.
- Again, the test should complete and there should be no error about missing test results.
