### PR TITLE
Use Vite include/exclude config

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,6 +1,7 @@
 import path, { sep } from 'path'
 import * as vscode from 'vscode'
 import minimatch from 'minimatch'
+import type { ResolvedConfig } from 'vitest'
 import parse from './pure/parsers'
 import type { NamedBlock } from './pure/parsers/parser_nodes'
 import type { TestData } from './TestData'
@@ -13,7 +14,7 @@ import {
 } from './TestData'
 import { shouldIncludeFile } from './vscodeUtils'
 
-import { getConfig, vitestEnvironmentFolders } from './config'
+import { getCombinedConfig, vitestEnvironmentFolders } from './config'
 import { log } from './log'
 
 export class TestFileDiscoverer extends vscode.Disposable {
@@ -22,8 +23,9 @@ export class TestFileDiscoverer extends vscode.Disposable {
   private workspaceCommonPrefix: Map<string, string> = new Map()
   private workspaceItems: Map<string, Set<vscode.TestItem>> = new Map()
   private pathToFileItem: Map<string, TestFile> = new Map()
+  private config: ResolvedConfig
 
-  constructor() {
+  constructor(config: ResolvedConfig) {
     super(() => {
       for (const watch of this.lastWatches)
         watch.dispose()
@@ -33,6 +35,7 @@ export class TestFileDiscoverer extends vscode.Disposable {
       this.pathToFileItem.clear()
       this.workspaceCommonPrefix.clear()
     })
+    this.config = config
     this.workspacePaths
       = vscode.workspace.workspaceFolders?.map(x => x.uri.fsPath) || []
   }
@@ -49,8 +52,8 @@ export class TestFileDiscoverer extends vscode.Disposable {
     const watchers = [] as vscode.FileSystemWatcher[]
     await Promise.all(
       vitestEnvironmentFolders.map(async (workspaceFolder) => {
-        const exclude = getConfig(workspaceFolder).exclude
-        for (const include of getConfig(workspaceFolder).include) {
+        const exclude = getCombinedConfig(this.config, workspaceFolder).exclude
+        for (const include of getCombinedConfig(this.config, workspaceFolder).include) {
           const pattern = new vscode.RelativePattern(
             workspaceFolder.uri,
             include,
@@ -103,8 +106,8 @@ export class TestFileDiscoverer extends vscode.Disposable {
 
     await Promise.all(
       vscode.workspace.workspaceFolders.map(async (workspaceFolder) => {
-        const exclude = getConfig(workspaceFolder).exclude
-        for (const include of getConfig(workspaceFolder).include) {
+        const exclude = getCombinedConfig(this.config, workspaceFolder).exclude
+        for (const include of getCombinedConfig(this.config, workspaceFolder).include) {
           const pattern = new vscode.RelativePattern(
             workspaceFolder.uri,
             include,
@@ -130,7 +133,7 @@ export class TestFileDiscoverer extends vscode.Disposable {
     if (e.uri.scheme !== 'file')
       return
 
-    if (!shouldIncludeFile(e.uri.fsPath))
+    if (!shouldIncludeFile(e.uri.fsPath, this.config))
       return
 
     const { file, data } = this.getOrCreateFile(ctrl, e.uri)

--- a/src/pure/watch/vitestConfig.ts
+++ b/src/pure/watch/vitestConfig.ts
@@ -1,0 +1,77 @@
+import { effect, reactive } from '@vue/reactivity'
+import type { ResolvedConfig } from 'vitest'
+import getPort from 'get-port'
+import { log } from '../../log'
+import type { VitestWorkspaceConfig } from '../../config'
+import { getConfig } from '../../config'
+import { execWithLog, sanitizeFilePath } from '../utils'
+import { createClient } from './ws-client'
+
+async function connectAndFetchConfig(
+  { port, url = `ws://localhost:${port}/__vitest_api__`, reconnectInterval, reconnectTries }: {
+    url?: string
+    port: number
+    reconnectInterval?: number
+    reconnectTries?: number
+  },
+) {
+  let onFailedConnection: (() => void) | undefined
+  const client = createClient(url, {
+    reactive: reactive as any,
+    reconnectInterval,
+    reconnectTries,
+    onFailedConnection: () => onFailedConnection?.(),
+  })
+
+  return new Promise<ResolvedConfig>((resolve, reject) => {
+    onFailedConnection = () => reject(new Error ('Unable to connect to Vitest API'))
+    const handled = new WeakSet()
+    effect(() => {
+      const ws = client.ws
+      if (!handled.has(ws)) {
+        handled.add(ws)
+        ws.addEventListener('open', () => {
+          log.info('WS Opened')
+          client.rpc.getConfig().then((_config) => {
+            client.dispose()
+            resolve(_config)
+          })
+        })
+
+        ws.addEventListener('error', (e) => {
+          console.error('WS ERROR', e)
+        })
+
+        ws.addEventListener('close', () => {
+          log.info('WS Close')
+        })
+      }
+    })
+  })
+}
+
+export async function fetchVitestConfig(
+  workspaceConfigs: VitestWorkspaceConfig[],
+) {
+  const port = await getPort()
+  const workspace = workspaceConfigs.find(workspace =>
+    workspace.isCompatible && !workspace.isDisabled && workspace.isUsingVitestForSure)
+  if (!workspace)
+    return
+  const folder = workspace.workspace.uri.fsPath
+  const childProcess = execWithLog(
+    workspace.cmd,
+    [...workspace.args, '--api.port', port.toString(), '--api.host', '127.0.0.1'],
+    {
+      cwd: sanitizeFilePath(folder),
+      env: { ...process.env, ...getConfig(folder).env },
+    },
+  ).child
+  const config = await connectAndFetchConfig({
+    port,
+    reconnectInterval: 500,
+    reconnectTries: 20,
+  })
+  childProcess.kill()
+  return config
+}

--- a/src/pure/watch/ws-client.ts
+++ b/src/pure/watch/ws-client.ts
@@ -93,6 +93,7 @@ export interface VitestClientOptions {
   reactive?: <T>(v: T) => T
   ref?: <T>(v: T) => { value: T }
   WebSocketConstructor?: typeof WebSocket
+  onFailedConnection?: () => void
 }
 
 export interface VitestClient {
@@ -112,6 +113,7 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
     reconnectTries = 10,
     reactive = v => v,
     WebSocketConstructor = globalThis.WebSocket,
+    onFailedConnection,
   } = options
 
   let tries = reconnectTries
@@ -190,6 +192,8 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
       tries -= 1
       if (!opened && autoReconnect && tries > 0)
         setTimeout(reconnect, reconnectInterval)
+      else if (autoReconnect && tries === 0)
+        onFailedConnection?.()
     })
   }
 

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -2,7 +2,8 @@ import { TextDecoder } from 'util'
 import type { Uri } from 'vscode'
 import { workspace } from 'vscode'
 import minimatch from 'minimatch'
-import { getConfig } from './config'
+import type { ResolvedConfig } from 'vitest'
+import { getCombinedConfig } from './config'
 
 const textDecoder = new TextDecoder('utf-8')
 
@@ -17,8 +18,8 @@ export const getContentFromFilesystem = async (uri: Uri) => {
   }
 }
 
-export function shouldIncludeFile(path: string) {
-  const { include, exclude } = getConfig()
+export function shouldIncludeFile(path: string, config: ResolvedConfig) {
+  const { include, exclude } = getCombinedConfig(config)
   return (
     include.some(x => minimatch(path, x))
     && exclude.every(x => !minimatch(path, x, { dot: true }))


### PR DESCRIPTION
## Done

Use include and exclude options from Vite config. This is done by connection to Vitest on startup and fetching the config.

It would be nice if there was a way to do this via a CLI command instead of starting the API connection, but I couldn't find a way to do that.

Fixes: #184.
Fixes: #173.
Fixes: #96.

## QA

- Remove any `vitest.include` or `vitest.exclude` options from your settings.json.
- Remove any `vitest.include` or `vitest.exclude` defaults in your package.json.
- Add an `include` or `exclude` option to `test: {...}` in your vite.config.(t|j)s or vitest.config.(t|j)s.
- Run this extension.
- The extension should identify the test files from the include/exclude options.
- Add some `vitest.include` or `vitest.exclude` options in your settings.json that are different from your vite.config/vitest.config.
- Run this extension again and it should use the options you've defined in your settings.json.
