### PR TITLE
Run tests in continuous mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/vitest-dev/vscode/issues"
   },
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.77.0"
   },
   "categories": [
     "Testing"
@@ -171,7 +171,7 @@
     "@types/glob": "^7.2.0",
     "@types/node": "^18.11.18",
     "@types/semver": "^7.3.9",
-    "@types/vscode": "^1.63.0",
+    "@types/vscode": "^1.77.0",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -112,6 +112,7 @@ export class TestFileDiscoverer extends vscode.Disposable {
             workspaceFolder.uri,
             include,
           )
+          const workspacePath = workspaceFolder.uri.fsPath
           const filter = (v: vscode.Uri) =>
             exclude.every(x => !minimatch(path.relative(workspacePath, v.fsPath), x, { dot: true }))
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,15 +160,9 @@ function registerWatchHandlers(
 
   const stopWatching = () => {
     testWatchers.forEach(watcher => watcher.dispose())
-    vscode.workspace
-      .getConfiguration('testing')
-      .update('automaticallyOpenPeekView', undefined)
   }
   const startWatching = () => {
     testWatchers.forEach(watcher => watcher.watch())
-    vscode.workspace
-      .getConfiguration('testing')
-      .update('automaticallyOpenPeekView', 'never')
   }
 
   context.subscriptions.push(
@@ -193,6 +187,8 @@ function registerWatchHandlers(
     vscode.TestRunProfileKind.Run,
     runHandler,
     false,
+    undefined,
+    true,
   )
 
   async function runHandler(

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -94,7 +94,7 @@ export async function updateSnapshot(
   const workspace = determineWorkspaceForTestItems([test], vscode.workspace.workspaceFolders)
   const runner = new TestRunner(workspace.uri.fsPath, getVitestCommand(workspace.uri.fsPath))
 
-  const request = new vscode.TestRunRequest([test])
+  const request = new vscode.TestRunRequest([test], undefined, undefined, true)
   const tests = [test]
   const run = ctrl.createTestRun(request)
   run.started(test)

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -209,7 +209,7 @@ export class TestWatcher extends Disposable {
       return
 
     if (!this.run)
-      this.run = this.ctrl.createTestRun(new TestRunRequest())
+      this.run = this.ctrl.createTestRun(new TestRunRequest(undefined, undefined, undefined, true))
 
     for (const file of files) {
       const data = this.discover.discoverTestFromPath(this.ctrl, file.filepath)
@@ -255,7 +255,7 @@ export class TestWatcher extends Disposable {
 
     const isFirstUpdate = !this.run
     if (isFirstUpdate)
-      this.run = this.ctrl.createTestRun(new TestRunRequest())
+      this.run = this.ctrl.createTestRun(new TestRunRequest(undefined, undefined, undefined, true))
 
     const discover = this.discover
     const ctrl = this.ctrl

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,10 +252,10 @@
   resolved "https://registry.npmmirror.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/vscode@^1.63.0":
-  version "1.67.0"
-  resolved "https://registry.npmmirror.com/@types/vscode/-/vscode-1.67.0.tgz#8eaba41d1591aa02f5d960b7dfae3b16e066f08c"
-  integrity sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==
+"@types/vscode@^1.77.0":
+  version "1.83.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.83.1.tgz#fe51b3d913a5c5b265a622179ae4ab6c0af7d54e"
+  integrity sha512-BHu51NaNKOtDf3BOonY3sKFFmZKEpRkzqkZVpSYxowLbs5JqjOQemYFob7Gs5rpxE5tiGhfpnMpcdF/oKrLg4w==
 
 "@types/ws@^8.5.3":
   version "8.5.3"


### PR DESCRIPTION
## Done

Run tests in continuous mode so the peek view can be controlled by the settings.

Fixes: #148.

## QA

- Run this extension.
- Open a test file and change a test to fail.
- Run the failing test and the peek view should appear.
- Close the peek view and then click the Vitest item in the status bar to run the tests in watch mode.
- The tests should run but the peek view should not appear.
- Open settings.json and add `"testing.automaticallyOpenPeekViewDuringAutoRun": true`.
- Run this extension again.
- Open the file with the failing test.
- Click the Vitest item in the status bar to run the tests in watch mode.
- The peek view should appear when the test fails.