### PR TITLE
fix: exclude/include config handling and missing workspacePath

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,8 +42,8 @@ export function getConfig(workspaceFolder?: WorkspaceFolder | vscode.Uri | strin
 export function getCombinedConfig(config: ResolvedConfig, workspaceFolder?: WorkspaceFolder | vscode.Uri | string) {
   const vitestConfig = getConfig(workspaceFolder)
   return {
-    exclude: vitestConfig.exclude || config.exclude || configDefaults.exclude,
-    include: vitestConfig.include || config.include || configDefaults.include,
+    exclude: vitestConfig.exclude?.concat(config.exclude) || configDefaults.exclude,
+    include: vitestConfig.include?.concat(config.include) || configDefaults.include,
   }
 }
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -106,6 +106,7 @@ export class TestFileDiscoverer extends vscode.Disposable {
 
     await Promise.all(
       vscode.workspace.workspaceFolders.map(async (workspaceFolder) => {
+        const workspacePath = workspaceFolder.uri.fsPath
         const exclude = getCombinedConfig(this.config, workspaceFolder).exclude
         for (const include of getCombinedConfig(this.config, workspaceFolder).include) {
           const pattern = new vscode.RelativePattern(


### PR DESCRIPTION
This PR fixes two issues related to test file inclusion/exclusion:

1. in `getCombinedConfig()` the deprecated vscode settings or better its default values, when  not found, always overruled the settings in the vite and vitest configs. By this change the entries in both configuration variants get merged.
 
Fixes Bugs in:  #187 

2. The fix in `discover.ts` just adds an obviously missing variable, which caused an error
 
![Pasted image](https://github.com/vitest-dev/vscode/assets/13013641/70be903a-6d53-4999-884e-617c9b185676)
