### PR TITLE
chore(settings): add "e2e" to default exclude list

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,12 +104,12 @@
           "scope": "resource"
         },
         "vitest.exclude": {
-          "markdownDescription": "Exclude globs for test files. \nDefault: `[\"**/node_modules/**\", \"**/dist/**\", \"**/cypress/**\", \"**/.{idea,git,cache,output,temp}/**\"]`",
+          "markdownDescription": "Exclude globs for test files. \nDefault: `[\"**/node_modules/**\", \"**/dist/**\", \"**/{cypress,e2e}/**\", \"**/.{idea,git,cache,output,temp}/**\"]`",
           "type": "array",
           "default": [
             "**/node_modules/**",
             "**/dist/**",
-            "**/cypress/**",
+            "**/{cypress,e2e}/**",
             "**/.{idea,git,cache,output,temp}/**"
           ],
           "scope": "resource"


### PR DESCRIPTION
`e2e` is a general folder name used for End-To-End tests, like `cypress`.