### PR TITLE
fix: show console logs in "Test Output"

### DIFF
--- a/samples/basic/test/add.test.ts
+++ b/samples/basic/test/add.test.ts
@@ -39,10 +39,14 @@ describe('addition', () => {
 describe('testing', () => {
   it('run', () => {
     const a = 10
+    console.log("foo", { a });
     expect(a).toBe(10)
   })
 
   it('mul', () => {
+    console.log("hey1");
+    console.log("hey2");
+    console.log("hey3");
     expect(5 * 5).toBe(25)
   })
 })

--- a/samples/basic/test/add.test.ts
+++ b/samples/basic/test/add.test.ts
@@ -39,14 +39,10 @@ describe('addition', () => {
 describe('testing', () => {
   it('run', () => {
     const a = 10
-    console.log("foo", { a });
     expect(a).toBe(10)
   })
 
   it('mul', () => {
-    console.log("hey1");
-    console.log("hey2");
-    console.log("hey3");
     expect(5 * 5).toBe(25)
   })
 })

--- a/samples/basic/test/console.test.ts
+++ b/samples/basic/test/console.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "vitest";
+
+describe("console", () => {
+  it("basic", () => {
+    console.log([
+      "string",
+      { hello: "world" },
+      1234,
+      /regex/g,
+      true,
+      false,
+      null,
+    ]);
+  });
+
+  it("async", async () => {
+    console.log("1st");
+    await sleep(200);
+    console.log("2nd");
+    await sleep(200);
+    console.log("3rd");
+  });
+});
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -306,12 +306,7 @@ async function runTest(
       ? WEAKMAP_TEST_DATA.get(items[0])!.getFullPattern()
       : '',
     {
-      info: (msg: string) => {
-        if (items.length === 1)
-          run.appendOutput(msg, undefined, items[0])
-        else
-          run.appendOutput(msg)
-      },
+      info: log.info,
       error: log.error,
     },
     config.env || undefined,
@@ -339,4 +334,3 @@ async function runTest(
     }
   }
 }
-

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -356,6 +356,15 @@ export function syncTestStatusToVsCode(
     for (const task of vitest) {
       const data = matchTask(task, set)
       if (task.type === 'test' || task.type === 'custom') {
+        // for now, display logs after all tests are finished.
+        // ideally, it might be possible to append logs during test execution via `onUserConsoleLog` rpc.
+        if (finished) {
+          for (const log of task.logs ?? []) {
+            // LF to CRLF https://code.visualstudio.com/api/extension-guides/testing#test-output
+            const output = log.content.replace(/(?<!\r)\n/g, "\r\n");
+            run.appendOutput(output, undefined, data.item);
+          }
+        }
         if (task.result == null) {
           if (finished) {
             finishedTest && finishedTest.add(data.item)

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -357,7 +357,7 @@ export function syncTestStatusToVsCode(
       const data = matchTask(task, set)
       if (task.type === 'test' || task.type === 'custom') {
         // for now, display logs after all tests are finished.
-        // ideally, it might be possible to append logs during test execution via `onUserConsoleLog` rpc.
+        // TODO: append logs during test execution using `onUserConsoleLog` rpc.
         if (finished) {
           for (const log of task.logs ?? []) {
             // LF to CRLF https://code.visualstudio.com/api/extension-guides/testing#test-output


### PR DESCRIPTION
- Closes https://github.com/vitest-dev/vscode/issues/137
- Closes https://github.com/vitest-dev/vscode/discussions/117

Currently this extension uses `TestRun.appendOutput` only to surface Vitest server logging:

https://github.com/vitest-dev/vscode/blob/d8c8908c07f8250f003e1a51d1088c2fb30c1415/src/runHandler.ts#L309-L314

This approach might work in some cases, but it seems inconsistent (for example, when running multiple tests at once).

I think the better way to surface logs for each test run is to use either:
- `Task.logs: UserConsoleLog[]` or
- `Reporter.onUserConsoleLog: (log: UserConsoleLog) => Awaitable<void>`

Ideally, we probably want to go with the 2nd approach `onUserConsoleLog` where we match Vitest's `log.taskId` against Vscode's `TestRun` to call specific `TestRun.appendOutput` in real time. But for this, it requires some more refactoring around vscode/vitest task matching utility, so for now I went with 1st approach where `Task.logs` are reliably available after the test is finished.

_todo_

- [x] check "Continuous Run" mode

<details><summary>Show demo</summary>

[스크린캐스트 2024-02-16 12-11-59.webm](https://github.com/vitest-dev/vscode/assets/4232207/ecdc87a3-aee8-488a-8c3d-4c221dd897bc)

</details>
