### PR TITLE
feat: add 'open' tag to test files that are open in editor

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,9 +1,7 @@
-import path, { sep } from 'path'
-import * as vscode from 'vscode'
 import minimatch from 'minimatch'
+import path, { sep } from 'path'
 import type { ResolvedConfig } from 'vitest'
-import parse from './pure/parsers'
-import type { NamedBlock } from './pure/parsers/parser_nodes'
+import * as vscode from 'vscode'
 import type { TestData } from './TestData'
 import {
   TestCase,
@@ -12,10 +10,13 @@ import {
   WEAKMAP_TEST_DATA,
   testItemIdMap,
 } from './TestData'
+import parse from './pure/parsers'
+import type { NamedBlock } from './pure/parsers/parser_nodes'
 import { shouldIncludeFile } from './vscodeUtils'
 
 import { getCombinedConfig, vitestEnvironmentFolders } from './config'
 import { log } from './log'
+import { openTestTag } from './tags'
 
 export class TestFileDiscoverer extends vscode.Disposable {
   private lastWatches = [] as vscode.FileSystemWatcher[]
@@ -139,6 +140,8 @@ export class TestFileDiscoverer extends vscode.Disposable {
 
     const { file, data } = this.getOrCreateFile(ctrl, e.uri)
     discoverTestFromFileContent(ctrl, e.getText(), file, data)
+
+    return file
   }
 
   discoverTestFromPath(
@@ -320,4 +323,28 @@ export function discoverTestFromFileContent(
       ]
     }
   }
+
+  const childTestItems = [fileItem]
+  const allTestItems = new Array<vscode.TestItem>()
+
+  while (childTestItems.length) {
+    const child = childTestItems.pop()
+    if (!child)
+      continue
+
+    allTestItems.push(child)
+    childTestItems.push(...[...child.children].map(x => x[1]))
+  }
+
+  const isFileOpen = vscode.workspace.textDocuments.some(
+    x => x.uri.fsPath === fileItem.uri?.fsPath,
+  )
+  const existingTagsWithoutOpenTag = fileItem.tags.filter(
+    x => x !== openTestTag,
+  )
+  const newTags = isFileOpen
+    ? [...existingTagsWithoutOpenTag, openTestTag]
+    : existingTagsWithoutOpenTag
+  for (const testItem of allTestItems)
+    testItem.tags = newTags
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode'
 import { effect } from '@vue/reactivity'
 
 import type { ResolvedConfig } from 'vitest'
+import { StatusBarItem } from './StatusBarItem'
+import { TestFile, WEAKMAP_TEST_DATA } from './TestData'
 import { Command } from './command'
 import {
   detectVitestEnvironmentFolders, extensionId, getVitestWorkspaceConfigs,
@@ -13,12 +15,11 @@ import { log } from './log'
 import {
   debugHandler, gatherTestItemsFromWorkspace, runHandler, updateSnapshot,
 } from './runHandler'
-import { StatusBarItem } from './StatusBarItem'
-import { TestFile, WEAKMAP_TEST_DATA } from './TestData'
 import { TestWatcher } from './watch'
 
 import type { VitestWorkspaceConfig } from './config'
 import { fetchVitestConfig } from './pure/watch/vitestConfig'
+import { openTestTag } from './tags'
 
 export async function activate(context: vscode.ExtensionContext) {
   await detectVitestEnvironmentFolders()
@@ -66,6 +67,11 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
     vscode.workspace.onDidOpenTextDocument((e) => {
       fileDiscoverer.discoverTestFromDoc(ctrl, e)
+    }),
+    vscode.workspace.onDidCloseTextDocument((e) => {
+      const item = fileDiscoverer.discoverTestFromDoc(ctrl, e)
+      if (item)
+        item.tags = item.tags.filter(x => x !== openTestTag)
     }),
     vscode.workspace.onDidChangeTextDocument(e =>
       fileDiscoverer.discoverTestFromDoc(ctrl, e.document),

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,0 +1,3 @@
+import { TestTag } from 'vscode'
+
+export const openTestTag = new TestTag('open')


### PR DESCRIPTION
This feature adds an 'open' tag that you can search for in the Test Explorer to only list tests that are currently open in the editor. Very handy when working on a feature that spans multiple tests.