### PR TITLE
feat: auto watch on startup setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,12 @@
           "scope": "resource",
           "default": false
         },
+        "vitest.watchOnStartup": {
+          "description": "Start watching tests on startup",
+          "type": "boolean",
+          "scope": "resource",
+          "default": false
+        },
         "vitest.commandLine": {
           "markdownDescription": "The command line to start vitest tests. **It should have with the ability to append extra arguments**. For example `npx vitest` or `yarn test --`\n\nThis is a workspace setting. Do not change it in the user setting directly, which will affect all the projects you open",
           "type": "string",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,10 @@
-import * as vscode from 'vscode'
 import semver from 'semver'
-import type { WorkspaceConfiguration, WorkspaceFolder } from 'vscode'
 import type { ResolvedConfig } from 'vitest'
+import type { WorkspaceConfiguration, WorkspaceFolder } from 'vscode'
+import * as vscode from 'vscode'
+import { log } from './log'
 import { isDefinitelyVitestEnv, mayBeVitestEnv } from './pure/isVitestEnv'
 import { getVitestCommand, getVitestVersion, isNodeAvailable } from './pure/utils'
-import { log } from './log'
 export const extensionId = 'zxch3n.vitest-explorer'
 
 // Copied from https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/defaults.ts
@@ -42,6 +42,7 @@ export function getConfig(workspaceFolder?: WorkspaceFolder | vscode.Uri | strin
   return {
     env: get<null | Record<string, string>>('nodeEnv', null),
     commandLine: get<string | undefined>('commandLine', undefined),
+    watchOnStartup: get<boolean>('watchOnStartup', false),
     include: get<string[]>('include'),
     exclude: get<string[]>('exclude'),
     enable: get<boolean>('enable', false),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { effect } from '@vue/reactivity'
 import type { ResolvedConfig } from 'vitest'
 import { Command } from './command'
 import {
-  detectVitestEnvironmentFolders, extensionId, getVitestWorkspaceConfigs,
+  detectVitestEnvironmentFolders, extensionId, getConfig, getVitestWorkspaceConfigs,
   vitestEnvironmentFolders,
 } from './config'
 import { TestFileDiscoverer } from './discover'
@@ -140,9 +140,14 @@ function registerWatchHandlers(
   fileDiscoverer: TestFileDiscoverer,
   context: vscode.ExtensionContext,
 ) {
-  const testWatchers = vitestConfigs.map((vitestConfig, index) =>
-    TestWatcher.create(ctrl, fileDiscoverer, vitestConfig, vitestConfig.workspace, index),
-  ) ?? []
+  const testWatchers = vitestConfigs.map((vitestConfig, index) => {
+    const watcher = TestWatcher.create(ctrl, fileDiscoverer, vitestConfig, vitestConfig.workspace, index)
+
+    if (getConfig(vitestConfig.workspace).watchOnStartup)
+      watcher.watch()
+
+    return watcher
+  }) ?? []
 
   statusBarItem = new StatusBarItem()
   effect(() => {


### PR DESCRIPTION
This PR adds a new setting that allows for Vite to start watching on startup.