### PR TITLE
Add support for Node.js modules in .mjs (.mts) format

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,13 @@
   },
   "activationEvents": [
     "workspaceContains:**/vitest.config.js",
+    "workspaceContains:**/vitest.config.mjs",
     "workspaceContains:**/vite.config.js",
+    "workspaceContains:**/vite.config.mjs",
     "workspaceContains:**/vitest.config.ts",
+    "workspaceContains:**/vitest.config.mts",
     "workspaceContains:**/vite.config.ts",
+    "workspaceContains:**/vite.config.mts",
     "workspaceContains:**/package.json"
   ],
   "contributes": {

--- a/src/pure/isVitestEnv.ts
+++ b/src/pure/isVitestEnv.ts
@@ -67,9 +67,13 @@ export async function mayBeVitestEnv(projectRoot: string | WorkspaceFolder): Pro
 
   if (
     existsSync(path.join(projectRoot, 'vite.config.js'))
+    || existsSync(path.join(projectRoot, 'vite.config.mjs'))
     || existsSync(path.join(projectRoot, 'vite.config.ts'))
+    || existsSync(path.join(projectRoot, 'vite.config.mts'))
     || existsSync(path.join(projectRoot, 'vitest.config.js'))
+    || existsSync(path.join(projectRoot, 'vitest.config.mjs'))
     || existsSync(path.join(projectRoot, 'vitest.config.ts'))
+    || existsSync(path.join(projectRoot, 'vitest.config.mts'))
   )
     return true
 


### PR DESCRIPTION
This pull request introduces support for .mjs and .mts file formats for configuration files within the Vitest VSCode extension. Previously, the extension lacked the capability to recognize or utilize configuration files written in module formats. This limitation posed a significant inconvenience for developers working in codebases that prefer these formats for their ES module compatibility and other benefits.