### PR TITLE
fix!: disabling continuous mode prevents future tests from being run

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,35 +45,12 @@
         "title": "Update Snapshot",
         "command": "vitest.updateSnapshot",
         "category": "Vitest"
-      },
-      {
-        "title": "Start Watch Mode",
-        "command": "vitest.startWatching",
-        "category": "Vitest"
-      },
-      {
-        "title": "Stop Watch Mode",
-        "command": "vitest.stopWatching",
-        "category": "Vitest"
-      },
-      {
-        "title": "Toggle Watch Mode",
-        "command": "vitest.toggleWatching",
-        "category": "Vitest"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "vitest.updateSnapshot",
-          "when": "false"
-        },
-        {
-          "command": "vitest.startWatching",
-          "when": "false"
-        },
-        {
-          "command": "vitest.stopWatching",
           "when": "false"
         }
       ],

--- a/src/StatusBarItem.ts
+++ b/src/StatusBarItem.ts
@@ -17,7 +17,6 @@ export class StatusBarItem extends vscode.Disposable {
   }
 
   toDefaultMode() {
-    this.item.command = Command.StartWatching
     this.item.text = '$(test-view-icon) Vitest'
     this.item.tooltip = 'Click to start watch mode'
     this.setBackgroundColor(false)
@@ -35,7 +34,6 @@ export class StatusBarItem extends vscode.Disposable {
       skipped: number
     },
   ) {
-    this.item.command = Command.StopWatching
     const total = passed + failed
     const percentOfExecutedTests = Number((passed / total * 100).toFixed(0))
     const percentIsValid = !Number.isNaN(percentOfExecutedTests)
@@ -51,7 +49,6 @@ export class StatusBarItem extends vscode.Disposable {
   }
 
   toRunningMode() {
-    this.item.command = Command.StopWatching
     this.item.text = '$(loading~spin) Vitest is running'
     this.item.tooltip = 'Click to stop watching'
     this.setBackgroundColor(false)

--- a/src/StatusBarItem.ts
+++ b/src/StatusBarItem.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'
-import { Command } from './command'
 import { getRootConfig } from './config'
 
 export class StatusBarItem extends vscode.Disposable {

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,3 @@
 export enum Command {
-  StartWatching = 'vitest.startWatching',
-  StopWatching = 'vitest.stopWatching',
   UpdateSnapshot = 'vitest.updateSnapshot',
-  ToggleWatching = 'vitest.toggleWatching',
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,9 +180,6 @@ function registerWatchHandlers(
   const stopWatching = () => {
     testWatchers.forEach(watcher => watcher.dispose())
   }
-  const startWatching = () => {
-    testWatchers.forEach(watcher => watcher.watch())
-  }
 
   context.subscriptions.push(
     {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,13 +212,17 @@ function registerWatchHandlers(
 
   async function runHandler(
     request: vscode.TestRunRequest,
-    _cancellation: vscode.CancellationToken,
+    cancellation: vscode.CancellationToken,
   ) {
     if (
       vscode.workspace.workspaceFolders === undefined
       || vscode.workspace.workspaceFolders.length === 0
     )
       return
+
+    cancellation.onCancellationRequested(() => {
+      testWatchers.forEach(watcher => watcher.dispose())
+    })
 
     await Promise.all(testWatchers.map(watcher => watcher.watch()))
     testWatchers.forEach((watcher) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,9 +47,6 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window.showWarningMessage(msg)
 
     context.subscriptions.push(
-      vscode.commands.registerCommand(Command.ToggleWatching, () => {
-        vscode.window.showWarningMessage(msg)
-      }),
       vscode.commands.registerCommand(Command.UpdateSnapshot, () => {
         vscode.window.showWarningMessage(msg)
       }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -190,15 +190,6 @@ function registerWatchHandlers(
     },
     ...testWatchers,
     statusBarItem,
-    vscode.commands.registerCommand(Command.StartWatching, startWatching),
-    vscode.commands.registerCommand(Command.StopWatching, stopWatching),
-    vscode.commands.registerCommand(Command.ToggleWatching, () => {
-      const anyWatching = testWatchers.some(watcher => watcher.isWatching.value)
-      if (anyWatching)
-        stopWatching()
-      else
-        startWatching()
-    }),
   )
 
   ctrl.createRunProfile(

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -194,7 +194,6 @@ async function runTest(
   const workspaceFolder = determineWorkspaceForTestItems(items, vscode.workspace.workspaceFolders!)
   const config = getConfig(workspaceFolder)
   const testCaseSet: Set<vscode.TestItem> = new Set()
-  const testItemIdMap = new Map<string, vscode.TestItem>()
   const fileItems: vscode.TestItem[] = []
   for (const item of items) {
     const testingData = WEAKMAP_TEST_DATA.get(item)
@@ -221,13 +220,6 @@ async function runTest(
     }
 
     fileItems.push(file)
-    const fileTestCases = getAllTestCases(file)
-    for (const testCase of fileTestCases) {
-      // remove suffix of test item id
-      // e.g. "test-case@1" -> "test-case"
-      // TODO: refactor
-      testItemIdMap.set(testCase.id.replace(/@\d+$/g, ''), testCase)
-    }
 
     for (const test of getAllTestCases(item))
       testCaseSet.add(test)


### PR DESCRIPTION
After the introduction of #178, there has been a quite critical bug. If you started continuous mode and then at a later point stopped it again, you could never manually run tests again until you restarted VS Code.

This was because watchers weren't disposed properly when continuous mode was being stopped.

This PR fixes that.

It also removes the watch commands, since they are now redundant. VS Code has inbuilt "start continuous mode" commands etc.