### PR TITLE
docs: fix install command in contribution guide

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -2,6 +2,6 @@
 
 How to build and test the extension:
 
-- Run `pnpm` to install deps
+- Run `pnpm install` to install deps
 - Run `pnpm watch`
 - Press F5 to run extension


### PR DESCRIPTION
`pnpm` does not have implied install on running `pnpm` so I fixed the instructions