### PR TITLE
fix: reference VS Code settings when determining vitest version

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -77,7 +77,8 @@ export interface VitestWorkspaceConfig {
 
 export async function getVitestWorkspaceConfigs(): Promise<VitestWorkspaceConfig[]> {
   return await Promise.all(vitestEnvironmentFolders.map(async (workspace) => {
-    const cmd = getVitestCommand(workspace.uri.fsPath)
+    const vscodeConfig = getConfig(workspace);
+    const cmd = getVitestCommand(workspace.uri.fsPath, vscodeConfig.commandLine)
 
     const version = cmd == null
       ? undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,7 +82,7 @@ export async function getVitestWorkspaceConfigs(): Promise<VitestWorkspaceConfig
 
     const version = cmd == null
       ? undefined
-      : await getVitestVersion(cmd, vscodeConfig.env || undefined).catch(async (e) => {
+      : await getVitestVersion(cmd, vscodeConfig.env || undefined, workspace.uri.fsPath).catch(async (e) => {
         log.info(e.toString())
         log.info(`process.env.PATH = ${process.env.PATH}`)
         log.info(`vitest.nodeEnv = ${JSON.stringify(vscodeConfig.env)}`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,12 +82,12 @@ export async function getVitestWorkspaceConfigs(): Promise<VitestWorkspaceConfig
 
     const version = cmd == null
       ? undefined
-      : await getVitestVersion(cmd, getConfig(workspace).env || undefined).catch(async (e) => {
+      : await getVitestVersion(cmd, vscodeConfig.env || undefined).catch(async (e) => {
         log.info(e.toString())
         log.info(`process.env.PATH = ${process.env.PATH}`)
-        log.info(`vitest.nodeEnv = ${JSON.stringify(getConfig(workspace).env)}`)
+        log.info(`vitest.nodeEnv = ${JSON.stringify(vscodeConfig.env)}`)
         let errorMsg = e.toString()
-        if (!isNodeAvailable(getConfig(workspace).env || undefined)) {
+        if (!isNodeAvailable(vscodeConfig.env || undefined)) {
           log.info('Cannot spawn node process')
           errorMsg += 'Cannot spawn node process. Please try setting vitest.nodeEnv as {"PATH": "/path/to/node"} in your settings.'
         }
@@ -96,7 +96,7 @@ export async function getVitestWorkspaceConfigs(): Promise<VitestWorkspaceConfig
         return undefined
       })
 
-    const isUsingVitestForSure = (getConfig(workspace).enable || await isDefinitelyVitestEnv(workspace) || (!!cmd)) && version != null
+    const isUsingVitestForSure = (vscodeConfig.enable || await isDefinitelyVitestEnv(workspace) || (!!cmd)) && version != null
     const disabled = getRootConfig().disabledWorkspaceFolders
     const out: VitestWorkspaceConfig = cmd
       ? {

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,7 +77,7 @@ export interface VitestWorkspaceConfig {
 
 export async function getVitestWorkspaceConfigs(): Promise<VitestWorkspaceConfig[]> {
   return await Promise.all(vitestEnvironmentFolders.map(async (workspace) => {
-    const vscodeConfig = getConfig(workspace);
+    const vscodeConfig = getConfig(workspace)
     const cmd = getVitestCommand(workspace.uri.fsPath, vscodeConfig.commandLine)
 
     const version = cmd == null

--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -33,12 +33,22 @@ export function getVitestPath(projectRoot: string): string | undefined {
 /**
  * if this function return a cmd, then this project is definitely using vitest
  * @param projectRoot
+ * @param settingsVitestCommand - the cmd to use for vitest, set in vscode settings
  */
 export function getVitestCommand(
   projectRoot: string,
+  settingsVitestCommand?: string,
 ): { cmd: string; args: string[] } | undefined {
   if (!projectRoot || projectRoot.length < 5)
     return
+
+  if (settingsVitestCommand && settingsVitestCommand.length > 0) {
+    const settingsCmdList = settingsVitestCommand.split(' ')
+    return {
+      cmd: settingsCmdList[0],
+      args: settingsCmdList.slice(1) || [],
+    }
+  }
 
   const node_modules = path.resolve(projectRoot, 'node_modules')
   try {

--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -94,12 +94,15 @@ export interface Cmd {
  *
  * @returns the version, or undefined if not found
  */
-export async function spawnVitestVersion(command: string, args: string[], env?: Record<string, string | undefined>): Promise<string | undefined> {
+export async function spawnVitestVersion(command: string, args: string[], env?: Record<string, string | undefined>, cwd?: string): Promise<string | undefined> {
   log.info(`Trying to get vitest version from ${command} ${args.join(' ')}...`)
+  if (cwd && cwd.length > 0) 
+    log.info(`Running command in directory: ${cwd}`)
 
   const child = spawn(command, args, {
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: isWindows,
+    cwd: cwd,
     env,
   })
 
@@ -126,15 +129,15 @@ export async function spawnVitestVersion(command: string, args: string[], env?: 
  * @returns the version
  * @throws an error if the version cannot be detected
  */
-export async function detectVitestVersion(command: string, args: string[], envs: Record<string, string | undefined>): Promise<string > {
+export async function detectVitestVersion(command: string, args: string[], envs: Record<string, string | undefined>, cwd?: string): Promise<string > {
   // Try to spawn the command directly
-  const version = await spawnVitestVersion(command, args, envs)
+  const version = await spawnVitestVersion(command, args, envs, cwd)
 
   if (version !== undefined)
     return version
 
   // When using a Node installed by a version manager, we need to pass the execPath to spawn
-  const versionExecPath = await spawnVitestVersion(process.execPath, [command, ...args], envs)
+  const versionExecPath = await spawnVitestVersion(process.execPath, [command, ...args], envs, cwd)
 
   if (versionExecPath !== undefined)
     return versionExecPath
@@ -145,13 +148,14 @@ export async function detectVitestVersion(command: string, args: string[], envs:
 export async function getVitestVersion(
   vitestCommand?: Cmd,
   env?: Record<string, string | undefined>,
+  cwd?: string,
 ): Promise<string | undefined> {
   const envs = { ...process.env, ...env }
 
   if (vitestCommand == null)
-    return await detectVitestVersion('npx', ['vitest', '-v'], envs)
+    return await detectVitestVersion('npx', ['vitest', '-v'], envs, cwd)
 
-  return await detectVitestVersion(vitestCommand.cmd, [...vitestCommand.args, '-v'], envs)
+  return await detectVitestVersion(vitestCommand.cmd, [...vitestCommand.args, '-v'], envs, cwd)
 }
 
 export function isNodeAvailable(

--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -96,13 +96,13 @@ export interface Cmd {
  */
 export async function spawnVitestVersion(command: string, args: string[], env?: Record<string, string | undefined>, cwd?: string): Promise<string | undefined> {
   log.info(`Trying to get vitest version from ${command} ${args.join(' ')}...`)
-  if (cwd && cwd.length > 0) 
+  if (cwd && cwd.length > 0)
     log.info(`Running command in directory: ${cwd}`)
 
   const child = spawn(command, args, {
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: isWindows,
-    cwd: cwd,
+    cwd,
     env,
   })
 


### PR DESCRIPTION
I am using yarn 4 pnp in my project, which is causing the default vitest binary resolution strategy (i.e. digging through `node_modules`) to fail. Given that we can pass in a command with which to run tests, I believe we should be able to use that command to determine the version of vitest. 

Look at the commit history for a summary of each change. I debugged this change by referencing [this PR](https://github.com/cameronbrill/portfolio/pull/20) in the `.vscode/launch.json` debug configuration. After these changes, I can finally run vitest tests in the native VS Code ui!

I appreciate any reviews!