### PR TITLE
feat: enable continuous mode for status button

### DIFF
--- a/src/StatusBarItem.ts
+++ b/src/StatusBarItem.ts
@@ -16,6 +16,7 @@ export class StatusBarItem extends vscode.Disposable {
   }
 
   toDefaultMode() {
+    this.item.command = 'testing.startContinuousRun'
     this.item.text = '$(test-view-icon) Vitest'
     this.item.tooltip = 'Click to start watch mode'
     this.setBackgroundColor(false)
@@ -33,6 +34,7 @@ export class StatusBarItem extends vscode.Disposable {
       skipped: number
     },
   ) {
+    this.item.command = 'testing.stopContinuousRun'
     const total = passed + failed
     const percentOfExecutedTests = Number((passed / total * 100).toFixed(0))
     const percentIsValid = !Number.isNaN(percentOfExecutedTests)
@@ -48,6 +50,7 @@ export class StatusBarItem extends vscode.Disposable {
   }
 
   toRunningMode() {
+    this.item.command = 'testing.stopContinuousRun'
     this.item.text = '$(loading~spin) Vitest is running'
     this.item.tooltip = 'Click to stop watching'
     this.setBackgroundColor(false)


### PR DESCRIPTION
Use VSCode's built-in commands "testing.startContinuousRun" and "testing.stopContinuousRun" to toggle continuous mode for the Vitest status button.