### PR TITLE
Fix errors when workspace path has spaces on Windows

### DIFF
--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -4,6 +4,7 @@ import { chunksToLinesAsync } from '@rauschma/stringio'
 import type { CancellationToken } from 'vscode'
 import type { File } from 'vitest'
 import {
+  addQuotes,
   filterColorFormatOutput,
   sanitizeFilePath,
 } from './utils'
@@ -87,7 +88,7 @@ export class TestRunner {
     const command = vitestCommand.cmd
     const args = [
       ...vitestCommand.args,
-      ...(testFile ? testFile.map(f => sanitizeFilePath(f)) : []),
+      ...(testFile ? testFile.map(f => addQuotes(sanitizeFilePath(f))) : []),
     ] as string[]
     if (updateSnapshot)
       args.push('--update')
@@ -105,7 +106,7 @@ export class TestRunner {
     const outputs: string[] = []
     const env = { ...process.env, ...workspaceEnv }
     let testResultFiles = [] as File[]
-    const output = await runVitestWithApi({ cmd: sanitizeFilePath(command), args }, this.workspacePath, {
+    const output = await runVitestWithApi({ cmd: addQuotes(sanitizeFilePath(command)), args }, this.workspacePath, {
       log: (line) => {
         log.info(`${filterColorFormatOutput(line.trimEnd())}\r\n`)
         outputs.push(filterColorFormatOutput(line))

--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -86,9 +86,18 @@ export class TestRunner {
     cancellation?: CancellationToken,
   ): Promise<{ testResultFiles: File[]; output: string }> {
     const command = vitestCommand.cmd
+
+    if (isWindows && !customStartProcess) {
+      testFile = testFile ? testFile.map(f => addQuotes(sanitizeFilePath(f))) : []
+    }
+    else {
+      // Debug mode automatically adds quotes
+      testFile = testFile ? testFile.map(f => sanitizeFilePath(f)) : []
+    }
+
     const args = [
       ...vitestCommand.args,
-      ...(testFile ? testFile.map(f => addQuotes(sanitizeFilePath(f))) : []),
+      ...testFile,
     ] as string[]
     if (updateSnapshot)
       args.push('--update')

--- a/src/pure/utils.ts
+++ b/src/pure/utils.ts
@@ -155,6 +155,9 @@ export async function getVitestVersion(
   if (vitestCommand == null)
     return await detectVitestVersion('npx', ['vitest', '-v'], envs, cwd)
 
+  if (vitestCommand.cmd.includes(' '))
+    return await detectVitestVersion(`"${vitestCommand.cmd}"`, [...vitestCommand.args, '-v'], envs, cwd)
+
   return await detectVitestVersion(vitestCommand.cmd, [...vitestCommand.args, '-v'], envs, cwd)
 }
 
@@ -172,6 +175,12 @@ export function isNodeAvailable(
       child.kill()
     }, 1000)
   })
+}
+
+export function addQuotes(path: string) {
+  if (path.includes(' '))
+    return `"${path}"`
+  return path
 }
 
 function capitalizeDriveLetter(path: string) {

--- a/src/pure/watch/vitestConfig.ts
+++ b/src/pure/watch/vitestConfig.ts
@@ -4,7 +4,7 @@ import type { ResolvedConfig } from 'vitest'
 import { log } from '../../log'
 import type { VitestWorkspaceConfig } from '../../config'
 import { getConfig } from '../../config'
-import { execWithLog, sanitizeFilePath } from '../utils'
+import { addQuotes, execWithLog, sanitizeFilePath } from '../utils'
 import { createClient } from './ws-client'
 
 async function connectAndFetchConfig(
@@ -60,7 +60,7 @@ export async function fetchVitestConfig(
     return
   const folder = workspace.workspace.uri.fsPath
   const childProcess = execWithLog(
-    workspace.cmd,
+    addQuotes(workspace.cmd),
     [...workspace.args, '--api.port', port.toString(), '--api.host', '127.0.0.1'],
     {
       cwd: sanitizeFilePath(folder),

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -58,13 +58,13 @@ export async function runHandler(
     if (testForThisWorkspace.length === 0)
       return
 
-    log.info(`[Workspace "${folder.name}] Run tests from workspace`)
+    log.info(`[Workspace ${folder.name}] Run tests from workspace`)
     try {
       await runTest(ctrl, runner, run, testForThisWorkspace, 'run', discover, cancellation)
-      log.info(`[Workspace "${folder.name}] Test run finished`)
+      log.info(`[Workspace ${folder.name}] Test run finished`)
     }
     catch (e) {
-      log.error(`[Workspace "${folder.name}] Run error`)
+      log.error(`[Workspace ${folder.name}] Run error`)
       if (e instanceof Error) {
         const err = e
         console.error(e)

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode'
 import type { ErrorWithDiff, File, ParsedStack, Task } from 'vitest'
 import { getConfig, getRootConfig } from './config'
 import type { TestFileDiscoverer } from './discover'
-import { execWithLog } from './pure/utils'
+import { addQuotes, execWithLog } from './pure/utils'
 import { buildWatchClient } from './pure/watch/client'
 import type { TestFile } from './TestData'
 import { TestCase, TestDescribe, WEAKMAP_TEST_DATA } from './TestData'
@@ -69,7 +69,7 @@ export class TestWatcher extends Disposable {
       const port = await getPort({ port: 51204 })
       let timer: any
       this.process = execWithLog(
-        this.vitest.cmd,
+        addQuotes(this.vitest.cmd),
         [...this.vitest.args, '--api.port', port.toString(), '--api.host', '127.0.0.1'],
         {
           cwd: this.workspace.uri.fsPath,


### PR DESCRIPTION
Add quotes to command and args when path contains spaces. Fixes #200 on Windows.

**Current status**
Running tests directly from play (▶) button: Works well
Running "Debug Test": Seems to work now
~Debug mode will add quotes again despite seemly using the same code as running tests directly.
Arguments become ""double quotes""~

Starting watch/continuous mode:
- On the "samples/basic" test folder, fails with `Error: No test suite found in file`, similar errors as https://github.com/vitest-dev/vitest/issues/3296
- Also has colour formatting errors in vscode output (use workaround `--no-color`）
![image](https://github.com/vitest-dev/vscode/assets/30391855/347c5841-c2ad-4acf-97f5-133af3ff95a6)

- On another personal repo, fails with `Error: Cannot read properties of undefined (reading 'test')` similar to https://github.com/vitest-dev/vitest/issues/5251

Any guidance would be appreciated.

Minor: removes quote typo in error log.