### PR TITLE
chore: typecheck test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "watch": "tsup --watch --sourcemap",
     "test": "vscode-test",
     "test:watch": "vscode-test --watch-files src/**/*.ts --watch-files test/**/*.test.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b ./ ./test",
     "lint": "eslint --cache .",
     "lint:fix": "eslint --cache --fix ."
   },
@@ -139,6 +139,7 @@
     "@types/fs-extra": "^9.0.13",
     "@types/glob": "^7.2.0",
     "@types/micromatch": "^4.0.6",
+    "@types/mocha": "^10.0.6",
     "@types/node": "^18.11.18",
     "@types/semver": "^7.3.9",
     "@types/vscode": "^1.77.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ devDependencies:
   '@types/micromatch':
     specifier: ^4.0.6
     version: 4.0.6
+  '@types/mocha':
+    specifier: ^10.0.6
+    version: 10.0.6
   '@types/node':
     specifier: ^18.11.18
     version: 18.19.17

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../tsconfig.base.json"],
+  "include": ["."],
+  "compilerOptions": {
+    "types": ["@types/mocha"]
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "ESNext.Disposable"],
-    "rootDir": "src",
-    "module": "commonJS",
-    "types": ["node"],
-    "strict": true,
-    "outDir": "out",
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["samples/**/*"]
+  "extends": ["./tsconfig.base.json"],
+  "include": ["src"]
 }


### PR DESCRIPTION
On my IDE, mocha typing wasn't working, so I tweaked tsconfig files for this.

<details><summary>before</summary>

![image](https://github.com/vitest-dev/vscode/assets/4232207/635039e5-d5d8-43be-834e-6a97d3b155de)

</details>

<details><summary>after</summary>

![image](https://github.com/vitest-dev/vscode/assets/4232207/0f32d486-2177-463c-80d8-df9e9a9f4e0f)

</details>
