### PR TITLE
feat: show basic diagnostics via LSP

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,9 @@
     "tsx": "^4.7.1",
     "typescript": "^5.3.3",
     "vitest": "^1.3.1",
+    "vscode-languageclient": "^9.0.1",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.11",
     "ws": "^8.16.0"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,15 @@ devDependencies:
   vitest:
     specifier: ^1.3.1
     version: 1.3.1(@types/node@18.19.17)
+  vscode-languageclient:
+    specifier: ^9.0.1
+    version: 9.0.1
+  vscode-languageserver:
+    specifier: ^9.0.1
+    version: 9.0.1
+  vscode-languageserver-textdocument:
+    specifier: ^1.0.11
+    version: 1.0.11
   ws:
     specifier: ^8.16.0
     version: 8.16.0
@@ -3204,6 +3213,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4429,6 +4445,42 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /vscode-languageclient@9.0.1:
+    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
+    engines: {vscode: ^1.82.0}
+    dependencies:
+      minimatch: 5.1.6
+      semver: 7.6.0
+      vscode-languageserver-protocol: 3.17.5
+    dev: true
+
+  /vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+    dev: true
+
+  /vscode-languageserver-textdocument@1.0.11:
+    resolution: {integrity: sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==}
+    dev: true
+
+  /vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+    dev: true
+
+  /vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
     dev: true
 
   /vue-eslint-parser@9.4.2(eslint@8.56.0):

--- a/samples/basic/test/diagnostics.test.ts
+++ b/samples/basic/test/diagnostics.test.ts
@@ -1,0 +1,14 @@
+import { describe, test } from "vitest";
+
+describe("testing", () => {
+  test("number 1", () => { })
+});
+describe("testing", () => {
+  test("number 2", () => { })
+  test("number 2", () => { })
+  describe("testing1", () => {})
+});
+
+describe("", () => { })
+
+test.each([1, 2])('a', () =>{})

--- a/src/languageServer.ts
+++ b/src/languageServer.ts
@@ -1,0 +1,279 @@
+import type {
+  CompletionItem,
+  Diagnostic,
+  InitializeParams,
+  InitializeResult,
+  TextDocumentPositionParams,
+} from 'vscode-languageserver/node'
+import {
+  CompletionItemKind,
+  DiagnosticSeverity,
+  DidChangeConfigurationNotification,
+  ProposedFeatures,
+  TextDocumentSyncKind,
+  TextDocuments,
+  createConnection,
+} from 'vscode-languageserver/node'
+
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import type { ParsedNode } from './pure/parsers/parser_nodes'
+import { DescribeBlock, ItBlock } from './pure/parsers/parser_nodes'
+import parse from './pure/parsers'
+
+// Create a connection for the server, using Node's IPC as a transport.
+// Also include all preview / proposed LSP features.
+const connection = createConnection(ProposedFeatures.all)
+
+// Create a simple text document manager.
+const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument)
+
+let hasConfigurationCapability: boolean = false
+let hasWorkspaceFolderCapability: boolean = false
+let hasDiagnosticRelatedInformationCapability: boolean = false
+
+connection.onInitialize((params: InitializeParams) => {
+  const capabilities = params.capabilities
+
+  // Does the client support the `workspace/configuration` request?
+  // If not, we fall back using global settings.
+  hasConfigurationCapability = !!(
+    capabilities.workspace && !!capabilities.workspace.configuration
+  )
+  hasWorkspaceFolderCapability = !!(
+    capabilities.workspace && !!capabilities.workspace.workspaceFolders
+  )
+  hasDiagnosticRelatedInformationCapability = !!(
+    capabilities.textDocument
+    && capabilities.textDocument.publishDiagnostics
+    && capabilities.textDocument.publishDiagnostics.relatedInformation
+  )
+
+  const result: InitializeResult = {
+    capabilities: {
+      textDocumentSync: TextDocumentSyncKind.Incremental,
+      // Tell the client that this server supports code completion.
+      completionProvider: {
+        resolveProvider: true,
+      },
+    },
+  }
+  if (hasWorkspaceFolderCapability) {
+    result.capabilities.workspace = {
+      workspaceFolders: {
+        supported: true,
+      },
+    }
+  }
+  return result
+})
+
+connection.onInitialized(() => {
+  if (hasConfigurationCapability) {
+    // Register for all configuration changes.
+    connection.client.register(DidChangeConfigurationNotification.type, undefined)
+  }
+  if (hasWorkspaceFolderCapability) {
+    connection.workspace.onDidChangeWorkspaceFolders((_event) => {
+      connection.console.log('Workspace folder change event received.')
+    })
+  }
+})
+
+// The example settings
+interface ExampleSettings {
+  maxNumberOfProblems: number
+}
+
+// The global settings, used when the `workspace/configuration` request is not supported by the client.
+// Please note that this is not the case when using this server with the client provided in this example
+// but could happen with other clients.
+const defaultSettings: ExampleSettings = { maxNumberOfProblems: 1000 }
+let globalSettings: ExampleSettings = defaultSettings
+
+// Cache the settings of all open documents
+const documentSettings: Map<string, Thenable<ExampleSettings>> = new Map()
+
+connection.onDidChangeConfiguration((change) => {
+  if (hasConfigurationCapability) {
+    // Reset all cached document settings
+    documentSettings.clear()
+  }
+  else {
+    globalSettings = <ExampleSettings>(
+      (change.settings.languageServerExample || defaultSettings)
+    )
+  }
+
+  // Revalidate all open text documents
+  documents.all().forEach(validateTextDocument)
+})
+
+function getDocumentSettings(resource: string): Thenable<ExampleSettings> {
+  if (!hasConfigurationCapability)
+    return Promise.resolve(globalSettings)
+
+  let result = documentSettings.get(resource)
+  if (!result) {
+    result = connection.workspace.getConfiguration({
+      scopeUri: resource,
+      section: 'vitestLanguageServer',
+    })
+    documentSettings.set(resource, result)
+  }
+  return result
+}
+
+// Only keep settings for open documents
+documents.onDidClose((e) => {
+  documentSettings.delete(e.document.uri)
+})
+
+// The content of a text document has changed. This event is emitted
+// when the text document first opened or when its content has changed.
+documents.onDidChangeContent((change) => {
+  validateTextDocument(change.document)
+})
+
+function validateTextDocument(textDocument: TextDocument): void {
+  const diagnostics: Diagnostic[] = []
+  const text = textDocument.getText()
+  function traverse(node: ParsedNode) {
+    if (!node.children)
+      return
+    type NamedBlock = DescribeBlock | ItBlock
+    const describeBlocks = new Map<string, NamedBlock[]>()
+    const itBlocks = new Map<string, ItBlock[]>()
+    const emptyBlocks: NamedBlock[] = []
+    const noPlaceholderEachBlocks: NamedBlock[] = []
+    function getPosition(node: ParsedNode) {
+      if (node.start == null || node.end == null)
+        return
+      const start = textDocument.positionAt(
+        textDocument.offsetAt({
+          line: node.start.line - 1,
+          character: node.start.column - 1,
+        }),
+      )
+      const end = textDocument.positionAt(
+        textDocument.offsetAt({
+          line: node.end.line - 1,
+          character: node.end.column - 1,
+        }),
+      )
+      return { start, end }
+    }
+    function groupByName<T extends NamedBlock>(block: T, map: Map<string, T[]>) {
+      const name = block.name
+      if (!name) {
+        emptyBlocks.push(block)
+      }
+      else {
+        const blocks = map.get(name) ?? []
+        blocks.push(block)
+        map.set(name, blocks)
+        if (block.lastProperty === 'each'
+          && !name.match(/[%$]/)
+        )
+          noPlaceholderEachBlocks.push(block)
+      }
+    }
+    for (const child of node.children) {
+      if (child instanceof DescribeBlock)
+        groupByName(child, describeBlocks)
+      else if (child instanceof ItBlock)
+        groupByName(child, itBlocks)
+    }
+    const duplicatedDescribeBlocks = Array.from(describeBlocks.entries()).filter(([_, describeBlocks]) => describeBlocks.length > 1)
+    const duplicatedItBlocks = Array.from(itBlocks.entries()).filter(([_, itBlocks]) => itBlocks.length > 1)
+    const duplicatedBlocks = [...duplicatedDescribeBlocks, ...duplicatedItBlocks]
+    for (const [name, duplication] of duplicatedBlocks) {
+      for (const d of duplication) {
+        const range = getPosition(d)
+        if (range == null)
+          continue
+        diagnostics.push({
+          severity: DiagnosticSeverity.Warning,
+          range,
+          message: `Duplicated ${d.type} block: '${name}'`,
+          source: 'Vitest',
+        })
+      }
+    }
+    for (const d of emptyBlocks) {
+      const range = getPosition(d)
+      if (range == null)
+        continue
+      diagnostics.push({
+        severity: DiagnosticSeverity.Warning,
+        range,
+        message: `Empty ${d.type} block`,
+        source: 'Vitest',
+      })
+    }
+    for (const d of noPlaceholderEachBlocks) {
+      const range = getPosition(d)
+      if (range == null)
+        continue
+      diagnostics.push({
+        severity: DiagnosticSeverity.Warning,
+        range,
+        message: `Each block '${d.name}' should have a placeholder`,
+        source: 'Vitest',
+      })
+    }
+    for (const child of node.children)
+      traverse(child)
+  }
+  traverse(parse(textDocument.uri, text).root)
+  // Send the computed diagnostics to VSCode.
+  connection.sendDiagnostics({ uri: textDocument.uri, diagnostics })
+}
+
+connection.onDidChangeWatchedFiles((_change) => {
+  // Monitored files have change in VS Code
+  connection.console.log('We received a file change event')
+})
+
+// This handler provides the initial list of the completion items.
+connection.onCompletion(
+  (_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+    // The pass parameter contains the position of the text document in
+    // which code complete got requested. For the example we ignore this
+    // info and always provide the same completion items.
+    return [
+      {
+        label: 'TypeScript',
+        kind: CompletionItemKind.Text,
+        data: 1,
+      },
+      {
+        label: 'JavaScript',
+        kind: CompletionItemKind.Text,
+        data: 2,
+      },
+    ]
+  },
+)
+
+// This handler resolves additional information for the item selected in
+// the completion list.
+connection.onCompletionResolve(
+  (item: CompletionItem): CompletionItem => {
+    if (item.data === 1) {
+      item.detail = 'TypeScript details'
+      item.documentation = 'TypeScript documentation'
+    }
+    else if (item.data === 2) {
+      item.detail = 'JavaScript details'
+      item.documentation = 'JavaScript documentation'
+    }
+    return item
+  },
+)
+
+// Make the text document manager listen on the connection
+// for open, change and close text document events
+documents.listen(connection)
+
+// Listen on the connection
+connection.listen()

--- a/src/pure/parsers/babel_parser.ts
+++ b/src/pure/parsers/babel_parser.ts
@@ -65,7 +65,7 @@ export function parse(file: string, data?: string, options?: parser.ParserOption
           name = _data.substring(arg.start + 1, arg.end - 1)
           break
         default:
-          name = _data.substring(arg.start, arg.end)
+          name = ''
           break
       }
     }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig([
   {
-    entry: ['./src/extension.ts'],
+    entry: ['./src/extension.ts', './src/languageServer.ts'],
     external: ['vscode'],
     format: 'cjs',
   },


### PR DESCRIPTION
Implemented basic diagnostic informations for test codes via VSCode Language Server. 
https://code.visualstudio.com/api/language-extensions/language-server-extension-guide

Now, warnings will be shown on undesirable test cases:
![image](https://github.com/vitest-dev/vscode/assets/927286/edfebabc-4fd0-4021-ac95-2a38374743b9)

Related to #259, duplicated desc/test blocks in same hierarchy can't be ran now. This feature aims to notice users undesirable naming cases. There're 3 diagnostic informations:

- Duplicated name blocks in same hierarchy 
- Empty name block
- `.each` blocks that has no placeholder

I'm novice of LSP. Would someone give me an advise?