### PR TITLE
fix: throw an error if test data is not found

### DIFF
--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -91,6 +91,7 @@ export class TestTree extends vscode.Disposable {
       range: undefined,
       error: undefined,
     }
+    TestFolder.register(item)
     this.folderItems.set(id, item)
     return item
   }

--- a/src/testTreeData.ts
+++ b/src/testTreeData.ts
@@ -6,7 +6,10 @@ export type TestData = TestFolder | TestFile | TestCase | TestSuite
 const WEAKMAP_TEST_DATA = new WeakMap<vscode.TestItem, TestData>()
 
 export function getTestData(item: vscode.TestItem): TestData {
-  return WEAKMAP_TEST_DATA.get(item)!
+  const data = WEAKMAP_TEST_DATA.get(item)
+  if (!data)
+    throw new Error(`Test data not found for "${item.label}". This is a bug in Vitest extension. Please report it to https://github.com/vitest-dev/vscode`)
+  return data
 }
 
 export function addTestData<T extends TestData>(item: vscode.TestItem, data: T): T {

--- a/test/TestData.test.ts
+++ b/test/TestData.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path'
 import * as vscode from 'vscode'
 import { expect } from 'chai'
-import { TestCase, TestFile, TestSuite } from '../src/testTreeData'
+import { TestCase, TestFile, TestSuite, getTestData } from '../src/testTreeData'
 
 describe('TestData', () => {
   const ctrl = vscode.tests.createTestController('mocha', 'Vitest')
@@ -63,6 +63,10 @@ describe('TestData', () => {
       expect(test1.getTestNamePattern()).to.equal('^\\s?describe test$')
       expect(test2.getTestNamePattern()).to.equal('^\\s?describe test 1$')
       expect(test3.getTestNamePattern()).to.equal('^\\s?describe test 2$')
+    })
+
+    it('throws an error if data was not set', () => {
+      expect(() => getTestData({ label: 'invalid test' } as any)).to.throw(/Test data not found for "invalid test"/)
     })
   })
 })


### PR DESCRIPTION
Related #341

I added a possible fix by registering an inlined item, but we now also throw an error if data is not found.