### PR TITLE
Default `NODE_ENV` to `test`

### DIFF
--- a/samples/basic/test/env.test.ts
+++ b/samples/basic/test/env.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from "vitest";
 test('process.env', () => {
   expect(process.env.TEST).toBe('true');
   expect(process.env.VITEST).toBe('true');
-  expect(process.env.NODE_ENV).toBe('true');
+  expect(process.env.NODE_ENV).toEqual('test');
   expect(process.env.VITEST_VSCODE).toBe('true');
   expect(process.env.TEST_CUSTOM_ENV).toBe('hello');
 });

--- a/samples/basic/test/env.test.ts
+++ b/samples/basic/test/env.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from "vitest";
 test('process.env', () => {
   expect(process.env.TEST).toBe('true');
   expect(process.env.VITEST).toBe('true');
-  expect(process.env.NODE_ENV).toEqual('test');
+  expect(process.env.NODE_ENV).toBe('test');
   expect(process.env.VITEST_VSCODE).toBe('true');
   expect(process.env.TEST_CUSTOM_ENV).toBe('hello');
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -254,7 +254,7 @@ function createChildVitestProcess(showWarning: boolean, meta: VitestPackage[]) {
         // https://github.com/vitest-dev/vitest/blob/5c7e9ca05491aeda225ce4616f06eefcd068c0b4/packages/vitest/src/node/cli/cli-api.ts
         TEST: 'true',
         VITEST: 'true',
-        NODE_ENV: env.NODE_ENV ?? process.env.NODE_ENV ?? 'true',
+        NODE_ENV: env.NODE_ENV ?? process.env.NODE_ENV ?? 'test',
       },
       stdio: 'overlapped',
       cwd: pnp ? dirname(pnp) : undefined,


### PR DESCRIPTION
Followup to https://github.com/vitest-dev/vscode/pull/309

When running the extension on a fresh install I could see the `NODE_ENV` by default is coming through as `true`. If we want to match the behavior of `startVitest` in  https://github.com/vitest-dev/vitest/blob/5c7e9ca05491aeda225ce4616f06eefcd068c0b4/packages/vitest/src/node/cli/cli-api.ts#L40 we should default to `test`.