### PR TITLE
feat: add name for the vitest-snapshot language

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "languages": [
       {
         "id": "vitest-snapshot",
+        "aliases": [
+          "Vitest Snapshot"
+        ],
         "extensions": [
           ".js.snap",
           ".jsx.snap",


### PR DESCRIPTION
The first alias in a language contribution is used as a human readable label. This is used in the status bar as well as the language selector.