### PR TITLE
fix: handle config de-sync when using workspaces

### DIFF
--- a/src/worker/coverage.ts
+++ b/src/worker/coverage.ts
@@ -16,7 +16,8 @@ export class VitestCoverage {
     private vitest: Vitest,
   ) {
     this._config = ctx.config.coverage
-    ctx.projects.forEach((project) => {
+    const projects = new Set([...ctx.projects, ctx.getCoreWorkspaceProject()])
+    projects.forEach((project) => {
       Object.defineProperty(project.config, 'coverage', {
         get: () => {
           return this.config
@@ -66,7 +67,6 @@ export class VitestCoverage {
     this.ctx.logger.log('Running coverage with configuration:', this.config)
 
     if (!this._provider) {
-      vitest.config.coverage.enabled = true
       // @ts-expect-error private method
       await vitest.initCoverageProvider()
       await vitest.coverageProvider?.clean(this._config.clean)
@@ -83,7 +83,7 @@ export class VitestCoverage {
   async waitForReport() {
     if (!this.enabled)
       return null
-    const coverage = this.config
+    const coverage = this.ctx.config.coverage
     if (!coverage.enabled || !this.ctx.coverageProvider)
       return null
     this.ctx.logger.error(`Waiting for the coverage report to generate: ${coverage.reportsDirectory}`)

--- a/src/worker/coverage.ts
+++ b/src/worker/coverage.ts
@@ -66,6 +66,7 @@ export class VitestCoverage {
     this.ctx.logger.log('Running coverage with configuration:', this.config)
 
     if (!this._provider) {
+      vitest.config.coverage.enabled = true
       // @ts-expect-error private method
       await vitest.initCoverageProvider()
       await vitest.coverageProvider?.clean(this._config.clean)
@@ -82,7 +83,7 @@ export class VitestCoverage {
   async waitForReport() {
     if (!this.enabled)
       return null
-    const coverage = this.ctx.config.coverage
+    const coverage = this.config
     if (!coverage.enabled || !this.ctx.coverageProvider)
       return null
     this.ctx.logger.error(`Waiting for the coverage report to generate: ${coverage.reportsDirectory}`)


### PR DESCRIPTION
Fixes #477

It seems that when using workspace configs the coverage `enabled` flag does not get set to `true`, so the call to `initCoverageProvider` doesn't actually initialize the provider. This causes the report to not generate and coverage to not show.

There is also a similar issue within `waitForReport` where using the coverage config from the context directly doesn't reflect the correct `enabled` flag, so using the local one ensures the flag is set correctly.

I suppose the _correct_ fix here would be figuring out why this flag is not syncing correctly with workspaces, but this is a simple workaround.

This can be validated using the `monorepo-vitest-workspace` sample, after these changes the coverage UI in VSCode should show correctly as in screenshot:

![Screenshot 2024-09-30 at 11 44 21](https://github.com/user-attachments/assets/7cd6c1a5-2c0a-4401-a2dc-832b1b3d4dd9)
