### PR TITLE
fix: always use same coverage output filename

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,5 @@ export const setupFilePath = resolve(__dirname, 'setupFile.mjs')
 
 export const configGlob = '**/*{vite,vitest}*.config*.{ts,js,mjs,cjs,cts,mts}'
 export const workspaceGlob = '**/*vitest.{workspace,projects}*.{ts,js,mjs,cjs,cts,mts,json}'
+
+export const finalCoverageFileName = 'coverage-final.json'

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -1,14 +1,13 @@
 import { readFileSync } from 'node:fs'
 import { IstanbulCoverageContext, IstanbulMissingCoverageError } from 'istanbul-to-vscode'
 import { join } from 'pathe'
+import { finalCoverageFileName } from './constants'
 
 export const coverageContext = new IstanbulCoverageContext()
 
-const FINAL_COVERAGE_FILE_NAME = 'coverage-final.json'
-
 export function readCoverageReport(reportsDirectory: string) {
   try {
-    return JSON.parse(readFileSync(join(reportsDirectory, FINAL_COVERAGE_FILE_NAME), 'utf8'))
+    return JSON.parse(readFileSync(join(reportsDirectory, finalCoverageFileName), 'utf8'))
   }
   catch (err: any) {
     throw new IstanbulMissingCoverageError(reportsDirectory, err)

--- a/src/worker/coverage.ts
+++ b/src/worker/coverage.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'pathe'
 import type { CoverageProvider, ResolvedCoverageOptions, Vitest as VitestCore } from 'vitest/node'
+import { finalCoverageFileName } from '../constants'
 import type { Vitest } from './vitest'
 
 export class VitestCoverage {
@@ -60,7 +61,12 @@ export class VitestCoverage {
     this._enabled = true
 
     const jsonReporter = this._config.reporter.find(([name]) => name === 'json')
-    this._config.reporter = [jsonReporter || ['json', {}]]
+    this._config.reporter = [
+      ['json', {
+        ...jsonReporter?.[1],
+        file: finalCoverageFileName,
+      }],
+    ]
     this._config.reportOnFailure = true
     this._config.reportsDirectory = join(tmpdir(), `vitest-coverage-${randomUUID()}`)
 


### PR DESCRIPTION
fixes #480

This ensures the filename used for the output json is always the same even if the user defined a custom one. This still preserves their other json reporter options which seems to have been the original intent here.