### PR TITLE
fix: close the rpc when the affected process is closed

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -174,7 +174,6 @@ export class VitestFolderAPI {
         log.error('[API]', 'Failed to close Vitest process', err)
       })
     }
-    this.meta.rpc.$close()
   }
 
   async cancelRun() {

--- a/src/api/child_process.ts
+++ b/src/api/child_process.ts
@@ -134,6 +134,11 @@ export async function createVitestProcess(pkg: VitestPackage): Promise<ResolvedM
     send: message => vitest.send(message),
   })
 
+  vitest.once('exit', () => {
+    log.verbose?.('[API]', 'Vitest child_process connection closed, cannot call RPC anymore.')
+    api.$close()
+  })
+
   return {
     rpc: api,
     process: new VitestChildProcess(vitest),

--- a/src/api/ws.ts
+++ b/src/api/ws.ts
@@ -27,6 +27,10 @@ export function waitForWsResolvedMeta(
             on: listener => ws.on('message', listener),
             send: message => ws.send(message),
           })
+          ws.once('close', () => {
+            log.verbose?.('[API]', 'Vitest WebSocket connection closed, cannot call RPC anymore.')
+            api.$close()
+          })
           resolve({
             rpc: api,
             handlers,


### PR DESCRIPTION
This is effectively the same as what we do already but it can catch unexpected exits better.