### PR TITLE
fix: run test in the correct project if Vitest workspace is used

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import { normalize, relative } from 'pathe'
 import * as vscode from 'vscode'
 import { log } from './log'
-import type { VitestEvents, VitestRPC } from './api/rpc'
+import type { SerializedTestSpecification, VitestEvents, VitestRPC } from './api/rpc'
 import type { VitestPackage } from './api/pkg'
 import { showVitestError } from './utils'
 import type { VitestProcess } from './api/types'
@@ -105,12 +105,12 @@ export class VitestFolderAPI {
     return this.pkg
   }
 
-  async runFiles(files?: string[], testNamePatern?: string) {
-    await this.meta.rpc.runTests(files?.map(normalize), testNamePatern)
+  async runFiles(specs?: SerializedTestSpecification[] | string[], testNamePatern?: string) {
+    await this.meta.rpc.runTests(normalizeSpecs(specs), testNamePatern)
   }
 
-  async updateSnapshots(files?: string[], testNamePatern?: string) {
-    await this.meta.rpc.updateSnapshots(files?.map(normalize), testNamePatern)
+  async updateSnapshots(specs?: SerializedTestSpecification[] | string[], testNamePatern?: string) {
+    await this.meta.rpc.updateSnapshots(normalizeSpecs(specs), testNamePatern)
   }
 
   getFiles() {
@@ -194,8 +194,8 @@ export class VitestFolderAPI {
     await this.meta.rpc.disableCoverage()
   }
 
-  async watchTests(files?: string[], testNamePattern?: string) {
-    await this.meta.rpc.watchTests(files?.map(normalize), testNamePattern)
+  async watchTests(files?: SerializedTestSpecification[] | string[], testNamePattern?: string) {
+    await this.meta.rpc.watchTests(normalizeSpecs(files), testNamePattern)
   }
 
   async unwatchTests() {
@@ -271,4 +271,16 @@ export interface ResolvedMeta {
     clearListeners: () => void
     removeListener: (name: string, listener: any) => void
   }
+}
+
+function normalizeSpecs(specs?: string[] | SerializedTestSpecification[]) {
+  if (!specs) {
+    return specs
+  }
+  return specs.map((spec) => {
+    if (typeof spec === 'string') {
+      return normalize(spec)
+    }
+    return [spec[0], normalize(spec[1])] as SerializedTestSpecification
+  }) as string[] | SerializedTestSpecification[]
 }

--- a/src/api/rpc.ts
+++ b/src/api/rpc.ts
@@ -2,14 +2,20 @@ import v8 from 'node:v8'
 import { type BirpcReturn, createBirpc } from 'birpc'
 import type { RunnerTestFile, TaskResultPack, UserConsoleLog } from 'vitest'
 
+export type SerializedTestSpecification = [
+  project: { name: string | undefined },
+  file: string,
+]
+
 export interface VitestMethods {
   getFiles: () => Promise<[project: string, file: string][]>
   collectTests: (testFile: [project: string, filepath: string][]) => Promise<void>
   cancelRun: () => Promise<void>
-  runTests: (files?: string[], testNamePattern?: string) => Promise<void>
-  updateSnapshots: (files?: string[], testNamePattern?: string) => Promise<void>
+  // accepts files with the project or folders (project doesn't matter for them)
+  runTests: (files?: SerializedTestSpecification[] | string[], testNamePattern?: string) => Promise<void>
+  updateSnapshots: (files?: SerializedTestSpecification[] | string[], testNamePattern?: string) => Promise<void>
 
-  watchTests: (files?: string[], testNamePattern?: string) => void
+  watchTests: (files?: SerializedTestSpecification[] | string[], testNamePattern?: string) => void
   unwatchTests: () => void
 
   enableCoverage: () => void

--- a/test-e2e/tester.ts
+++ b/test-e2e/tester.ts
@@ -23,8 +23,9 @@ export class VSCodeTester {
 
   async runAllTests() {
     await this.page
-      .getByRole('toolbar', { name: 'Test Explorer actions', exact: true })
+      .getByRole('toolbar', { name: 'Testing actions', exact: true })
       .getByRole('button', { name: /^Run Tests$/ })
+      .first()
       .click()
   }
 }

--- a/test-e2e/tester.ts
+++ b/test-e2e/tester.ts
@@ -22,7 +22,10 @@ export class VSCodeTester {
   }
 
   async runAllTests() {
-    await this.page.getByRole('button', { name: /^Run Tests$/ }).click()
+    await this.page
+      .getByRole('toolbar', { name: 'Test Explorer actions', exact: true })
+      .getByRole('button', { name: /^Run Tests$/ })
+      .click()
   }
 }
 


### PR DESCRIPTION
Fixes #516