### PR TITLE
Add stack traces to test message for test error.

### DIFF
--- a/samples/basic/src/add.ts
+++ b/samples/basic/src/add.ts
@@ -1,7 +1,17 @@
+
 export function add(a: number, b: number) {
   return a + b
 }
 
 export function sum(from: number, to: number) {
   return (from + to) * (to - from + 1) / 2
+}
+
+export function addError(from: number, to: number) {
+  doSomething()
+  return add(from, to)
+}
+
+function doSomething() {
+  throw new Error('Something went wrong');
 }

--- a/samples/basic/test/throw.test.ts
+++ b/samples/basic/test/throw.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { addError } from '../src/add';
+
+describe('throw error', () => {
+  it('passes expecting an error to be thrown', () => {
+    expect(()=>addError(1, 1)).toThrow()
+  })
+
+  it('fails with error thrown', () => {
+    expect(addError(1, 1)).toBe(2)
+  })
+})


### PR DESCRIPTION
- For thrown error scenarios provides the location of the error thrown inside the tested code with fully navigable trace.
- For non throw error scenarios provides additional context on the failed assertion.

|| Before | After |
|--------|--------|--------|
| Assert | ![assertion - before](https://github.com/user-attachments/assets/fb4e70c0-f744-4f1b-a2ee-95c4a1ecfa57) | ![assertion - after](https://github.com/user-attachments/assets/998367a0-9be3-467f-af2d-d70a1c971778) |
| Exception | ![exception - before](https://github.com/user-attachments/assets/1f393147-b4b5-4733-927d-f5cef151025a) | ![exception - after](https://github.com/user-attachments/assets/79e874bc-ac1e-4f38-8e21-9d66b8798cab) | 




