### PR TITLE
hotfix for adding stack traces for error as the feature was added only in vscode 1.93

### DIFF
--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -507,7 +507,7 @@ function testMessageForTestError(testItem: vscode.TestItem, error: TestError | u
   else
     testMessage = new vscode.TestMessage(stripVTControlCharacters(error.message) ?? '')
 
-  testMessage.stackTrace = parseMessageStackFramesFromErrorStacks(error.stacks)
+  setMessageStackFramesFromErrorStacks(testMessage, error.stacks)
 
   const location = parseLocationFromStacks(testItem, error.stacks ?? [])
   if (location) {
@@ -552,15 +552,22 @@ function parseLocationFromStacks(testItem: vscode.TestItem, stacks: ParsedStack[
   log.verbose?.('Could not find a valid stack for', testItem.label, JSON.stringify(stacks, null, 2))
 }
 
-function parseMessageStackFramesFromErrorStacks(stacks: ParsedStack[] | undefined): vscode.TestMessageStackFrame[] | undefined {
+function setMessageStackFramesFromErrorStacks(testMessage: vscode.TestMessage, stacks: ParsedStack[] | undefined) {
+  // Error stack frames are available only in ^1.93
+  if (!('TestMessageStackFrame' in vscode))
+    return
   if (!stacks || stacks.length === 0)
-    return undefined
+    return
 
-  return stacks.map((stack) => {
+  const TestMessageStackFrame = (vscode as any).TestMessageStackFrame
+
+  const frames = stacks.map((stack) => {
     const { sourceFilepath, line, column } = getSourceFilepathAndLocationFromStack(stack)
     const sourceUri = sourceFilepath ? vscode.Uri.file(sourceFilepath) : undefined
-    return new vscode.TestMessageStackFrame(stack.method, sourceUri, new vscode.Position(line - 1, column - 1))
-  })
+    return new TestMessageStackFrame(stack.method, sourceUri, new vscode.Position(line - 1, column - 1))
+  });
+
+  (testMessage as any).stackTrace = frames
 }
 
 function getTestFiles(tests: readonly vscode.TestItem[]): string[] | SerializedTestSpecification[] {


### PR DESCRIPTION
test:
pnpm typecheck
pnpm lint
pnpm test

+run manually

p.s. sorry, no idea how local vscode typing just worked