### PR TITLE
fix: node path detection for lazy loading

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -162,7 +162,7 @@ async function findNodeViaShell(cwd: string): Promise<string | undefined> {
     const startToken = '___START_SHELL__'
     const endToken = '___END_SHELL__'
     try {
-      const childProcess = spawn(`${vscode.env.shell} -i -c 'echo ${startToken} && which node && echo ${endToken}'`, {
+      const childProcess = spawn(`${vscode.env.shell} -i -c 'if type node 2>/dev/null | grep -q "function"; then node --version; fi; echo ${startToken} && which node && echo ${endToken}'`, {
         stdio: 'pipe',
         shell: true,
         cwd,


### PR DESCRIPTION
close: https://github.com/vitest-dev/vscode/issues/542

More background: https://github.com/microsoft/playwright/issues/33996#issuecomment-2542290911

NVM lazy loading use cases such as the Oh My Zsh `nvm` plugin might make node a function which will be executed to set the node path when it is run, so executed the `node` command if it is a function to make it point to the real Node binary.