### PR TITLE
fix: resolve ancestral symlinks

### DIFF
--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -192,10 +192,7 @@ export class TestTree extends vscode.Disposable {
     const parent = dirname(normalizedFolder)
     // If the parent is the same as the folder, we are at the root
     if (parent === normalizedFolder) {
-      log.workspaceError(
-        `Fatal error: Attempted to get parent for root folder. Aborting to prevent infinite loop.`,
-      )
-      return this.loaderItem
+      throw new Error(`Fatal Error: Attempted to get parent of root folder "${normalizedFolder}".`)
     }
 
     const folderUri = vscode.Uri.file(normalizedFolder)


### PR DESCRIPTION
## Why
My development box has a symlink from home into my mounts directory: `/home/zinefer/code` => `/mnt/code`

The `getOrCreateFolderTestItem` function expects a cache hit and if it does not find one, it will continue to recurse forever at the filesystem root.

If I open a project, say, `/home/zinefer/code/github.com/vitest-dev/vscode`, it will result in a call chain like so:
```
[depth=0] normalizedFolder: /mnt/code/github.com/vitest-dev/vscode/some/test/path
[depth=0] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=1] normalizedFolder: /mnt/code/github.com/vitest-dev/vscode/some/test
[depth=1] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=2] normalizedFolder: /mnt/code/github.com/vitest-dev/vscode/some
[depth=2] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=3] normalizedFolder: /mnt/code/github.com/vitest-dev/vscode
[depth=3] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=4] normalizedFolder: /mnt/code/github.com/vitest-dev
[depth=4] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=5] normalizedFolder: /mnt/code/github.com
[depth=5] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=6] normalizedFolder: /mnt/code
[depth=6] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=7] normalizedFolder: /mnt
[depth=7] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=8] normalizedFolder: /
[depth=8] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=9] normalizedFolder: /
[depth=9] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
[depth=10] normalizedFolder: /
[depth=10] folderItems: /home/zinefer/code/github.com/vitest-dev/vscode
{ Infinite }
```

## What
I've replaced the lstat based symlink resolution with [realpath](https://nodejs.org/api/fs.html#fsrealpathpath-options-callback). This will resolve the symlink in the upper part of the path and allow for a cache hit inside `getOrCreateFolderTestItem`.

I've also added a runtime check to detect the infinite loop, prevent it and log an error.