### PR TITLE
docs: remove NX support references from docs and config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,16 +116,6 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"]
     },
     {
-      "name": "Run Extension Monorepo NX",
-      "type": "extensionHost",
-      "request": "launch",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
-        "${workspaceFolder}/samples/monorepo-nx"
-      ],
-      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
-    },
-    {
       "name": "Run Extension React Sample",
       "type": "extensionHost",
       "request": "launch",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 - **Run**, **debug**, and **watch** Vitest tests in Visual Studio Code.
 - **Coverage** support (requires VS Code >= 1.88)
-- NX support (see the [NX sample](./samples/monorepo-nx/)).
 - An `@open` tag can be used when filtering tests, to only show the tests open in the editor.
 
 ## Requirements


### PR DESCRIPTION
## 背景
在查看 vitest 插件相关文档时，发现 README 中关于 NX 功能的链接点击后显示 404 错误。  
经排查，相关 NX 功能内容已在 commit `c9644366a0e7dead9eb2720aa55a21e87c95e222` 中被删除，导致链接失效。

## 变更内容
- 移除 README 中涉及 NX 功能的描述及对应链接
- 删除 debug 配置中与 NX 相关的失效内容

## Background
When reviewing the documentation related to the Vitest plugin, it was found that the link to the NX functionality in the README returns a 404 error when clicked.  
After investigation, the relevant NX functionality content was removed in the commit `c9644366a0e7dead9eb2720aa55a21e87c95e222`, resulting in the invalidation of the link.

## Change Content
- Remove the descriptions and corresponding links related to NX functionality in the README
- Delete the invalid content related to NX in the debug configuration