### PR TITLE
Update configSearchPatternExclude default config to exclude 'vendor' directory

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -39,7 +39,7 @@ export function getConfig(workspaceFolder?: WorkspaceFolder) {
 
   const configSearchPatternExclude = get<string>(
     'configSearchPatternExclude',
-    '{**/node_modules/**,**/.*/**,**/*.d.ts}',
+    '{**/node_modules/**,**/vendor/**,**/.*/**,**/*.d.ts}',
   )!
 
   const configSearchPatternInclude = get<string>(


### PR DESCRIPTION
When running this extension within the scope of my Laravel project (with Yarn PnP), on opening the project I was immediately faced with the error message "The extension could not load some configs. Check the output for more details.". After investigating this (see also trace below), I figured the cause was (Laravel) dependencies having Vite/Vitest configuration files within their contents.

I could simply mitigate the problem by manually adjusting the `configSearchPatternExclude` configuration value for my project, however as I consider `vendor` to be a directory that is most commonly if not exclusively used for dependencies, I figured it would make sense to introduce this as a default exclude, hence this PR.

## Error message
```
Error: Your application tried to access @tailwindcss/vite, but it isn't declared in your dependencies; this makes the require call ambiguous and unsound.

Required package: @tailwindcss/vite (via "@tailwindcss\vite\package.json")
Required by: <project-root>\vendor\laravel\framework\src\Illuminate\Foundation\resources\exceptions\renderer\vite.config.js.timestamp-1764844721793-8dea9b492cb62.mjs

    at makeError (<project-root>\.pnp.cjs:19591:34)
    at resolveToUnqualified (<project-root>\.pnp.cjs:21227:21)
    at Object.resolveToUnqualified (<project-root>\.pnp.cjs:21417:26)
    at resolve$1 (file:///<project-root>/.pnp.loader.mjs:2031:31)
    at nextResolve (node:internal/modules/esm/hooks:769:28)
    at AsyncLoaderHooksOnLoaderHookWorker.resolve (node:internal/modules/esm/hooks:265:30)
    at handleMessage (node:internal/modules/esm/worker:251:24)
    at checkForMessages (node:internal/modules/esm/worker:193:28)
    at process.<anonymous> (node:internal/modules/esm/worker:212:5)
    at process.emit (node:events:508:28)
Error: Vitest failed to start: 
Error: Your application tried to access @tailwindcss/vite, but it isn't declared in your dependencies; this makes the require call ambiguous and unsound.
```