### PR TITLE
Fix: change `@vitest/browser/context` import to `vitest/browser`

### DIFF
--- a/packages/extension/src/worker/browserSetupFile.ts
+++ b/packages/extension/src/worker/browserSetupFile.ts
@@ -1,4 +1,4 @@
-import { commands, server } from '@vitest/browser/context'
+import { commands, server } from 'vitest/browser'
 
 if (server.config.inspector.enabled) {
   // @ts-expect-error __vscode_waitForDebugger is not defined

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig([
   },
   {
     entry: ['./packages/extension/src/worker/browserSetupFile.ts'],
-    external: ['vitest', '@vitest/browser/context'],
+    external: ['vitest', 'vitest/browser'],
     fixedExtension: false,
     inlineOnly: false,
     platform: 'node',


### PR DESCRIPTION
This should resolve the following warning when debugging tests:
> DEPRECATED  C:/Users/me/.vscode/extensions/vitest.explorer-1.44.1/dist/browserSetupFile.mjs tries to load a deprecated "@vitest/browser/context" module. This import will stop working in the next major version. Please, use "vitest/browser" instead.
