### PR TITLE
fix: normalize Windows drive letter when matching test failure stacks

### DIFF
--- a/packages/extension/src/runner.ts
+++ b/packages/extension/src/runner.ts
@@ -552,7 +552,7 @@ function parseLocationFromStacks(
 ): DebuggerLocation | undefined {
   if (stacks.length === 0) return undefined
 
-  const targetFilepath = testItem.uri!.fsPath
+  const targetFilepath = normalizeDriveLetter(testItem.uri!.fsPath)
   for (const stack of stacks) {
     const { sourceFilepath, line, column } = getSourceFilepathAndLocationFromStack(stack)
     const sourceNormalizedPath = sourceFilepath && normalizeDriveLetter(sourceFilepath)


### PR DESCRIPTION
## Summary

- Fix Windows test failure squiggles not appearing when `vitest.applyDiagnostic` is enabled
- Normalize the test item file path with `normalizeDriveLetter()` in `parseLocationFromStacks`, matching how stack paths are already normalized

Fixes #795

## Problem

On Windows, Vitest stack frames use an uppercase drive letter (`C:\...`) while VS Code's `testItem.uri.fsPath` uses lowercase (`c:\...`). `parseLocationFromStacks` only normalized the stack side, so the path comparison failed and the extension logged "Could not find a valid stack" instead of drawing a diagnostic squiggle.

## Test plan

- [ ] On Windows, open a project with Vitest tests
- [ ] Enable `vitest.applyDiagnostic` (default)
- [ ] Run a failing test from the Testing panel
- [ ] Confirm a squiggle appears on the failing `expect(...)` line
- [ ] Confirm CI passes (`pnpm typecheck`, `pnpm test`, `pnpm test-e2e`)
