### PR TITLE
feat: set diagnostic.source="Vitest"

### DIFF
--- a/packages/extension/src/diagnostic.ts
+++ b/packages/extension/src/diagnostic.ts
@@ -15,6 +15,7 @@ export class ExtensionDiagnostic {
         error.message.toString(),
         vscode.DiagnosticSeverity.Error,
       )
+      diagnostic.source = 'Vitest';
       diagnostics.push(diagnostic)
     })
     this.diagnostic.set(testFile, diagnostics)


### PR DESCRIPTION
Set the source field to "Vitest" when inserting new diagnostics into vscode.