### PR TITLE
fix: pick the closest config's run profile when several configs claim a test file

### DIFF
--- a/packages/extension/src/configOwnership.ts
+++ b/packages/extension/src/configOwnership.ts
@@ -1,0 +1,27 @@
+import { dirname, isAbsolute, normalize, relative } from 'pathe'
+
+/**
+ * Number of path segments in the config's directory if the test file is inside
+ * of it, or -1 if it is not. Higher means the config is closer to the test file.
+ */
+export function getConfigSpecificity(configFile: string | undefined, testFile: string): number {
+  if (!configFile) {
+    return -1
+  }
+  const configDir = dirname(normalize(configFile))
+  const relativePath = relative(configDir, normalize(testFile))
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    return -1
+  }
+  return configDir.split('/').filter(Boolean).length
+}
+
+export function isCloserConfig(
+  candidateConfig: string | undefined,
+  currentConfig: string | undefined,
+  testFile: string,
+): boolean {
+  return (
+    getConfigSpecificity(candidateConfig, testFile) > getConfigSpecificity(currentConfig, testFile)
+  )
+}

--- a/packages/extension/src/testTree.ts
+++ b/packages/extension/src/testTree.ts
@@ -8,6 +8,7 @@ import { realpathSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { basename, dirname, normalize } from 'pathe'
 import * as vscode from 'vscode'
+import { isCloserConfig } from './configOwnership'
 import { log } from './log'
 import { getTestData, TestCase, TestFile, TestFolder, TestSuite } from './testTreeData'
 import { ExtensionWatcher } from './watcher'
@@ -146,7 +147,10 @@ export class TestTree extends vscode.Disposable {
     const normalizedFile = normalize(file)
     const fileId = `${normalizedFile}${project}`
     const cached = this.fileItems.get(fileId)
-    if (cached) return cached
+    if (cached) {
+      this.retagFileItemIfCloser(cached, api, metadata, file)
+      return cached
+    }
 
     const fileUri = vscode.Uri.file(resolve(file))
     const parentItem = this.getOrCreateFolderTestItem(api, dirname(file))
@@ -167,6 +171,36 @@ export class TestTree extends vscode.Disposable {
     vscode.commands.executeCommand('setContext', 'vitest.testFiles', [...this.testFiles])
 
     return testFileItem
+  }
+
+  /**
+   * Several instances can claim the same test item - e.g. a shared base config at
+   * the root and a package config both match the same file. The item's tag decides
+   * which run profile VSCode picks for ambiguous runs (gutter, tree run button), so
+   * the instance whose config is closest to the file tags the item. Every instance
+   * still runs the file in its own full runs - nothing is deduplicated away, and any
+   * profile can still be chosen explicitly via "Execute Using Profile...".
+   */
+  private retagFileItemIfCloser(
+    item: vscode.TestItem,
+    api: VitestProcessAPI,
+    metadata: TestFileMetadata,
+    file: string,
+  ) {
+    const data = getTestData(item)
+    if (!(data instanceof TestFile) || data.api === api) return
+
+    const currentConfig = data.api.package.id
+    const candidateConfig = api.package.id
+    if (!isCloserConfig(candidateConfig, currentConfig, data.filepath)) return
+
+    log.info(
+      '[TEST TREE]',
+      `"${candidateConfig}" now provides the default run profile for "${data.filepath}" because it is defined closer to the test file than "${currentConfig}".`,
+    )
+    const parentItem = this.getOrCreateFolderTestItem(api, dirname(file))
+    item.tags = [api.tag]
+    TestFile.register(item, parentItem, data.filepath, api, metadata)
   }
 
   getOrCreateFolderTestItem(api: VitestProcessAPI, normalizedFolder: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,15 @@ importers:
         specifier: catalog:latest
         version: 4.1.0(@types/node@24.10.1)(@vitest/browser-playwright@4.1.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
+  samples/monorepo-base-config:
+    devDependencies:
+      vite:
+        specifier: catalog:latest
+        version: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: catalog:latest
+        version: 4.1.0(@types/node@24.10.1)(@vitest/browser-playwright@4.1.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
   samples/monorepo-vitest-workspace:
     devDependencies:
       '@vitest/coverage-v8':

--- a/samples/monorepo-base-config/package.json
+++ b/samples/monorepo-base-config/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "monorepo-base-config",
+  "version": "1.0.0",
+  "private": true,
+  "description": "",
+  "license": "ISC",
+  "author": "",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vite": "catalog:latest",
+    "vitest": "catalog:latest"
+  }
+}

--- a/samples/monorepo-base-config/packages/foo/test/tagged.test.ts
+++ b/samples/monorepo-base-config/packages/foo/test/tagged.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from 'vitest'
+
+it('runs with the integration tag', { tags: ['integration'] }, () => {
+  expect(1).toBe(1)
+})
+
+it('runs without a tag', () => {
+  expect(2).toBe(2)
+})

--- a/samples/monorepo-base-config/packages/foo/vitest.config.ts
+++ b/samples/monorepo-base-config/packages/foo/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import baseConfig from '../../vitest.config.base'
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      tags: [
+        {
+          description: 'A tag that is only defined in the package config.',
+          name: 'integration',
+        },
+      ],
+    },
+  }),
+)

--- a/samples/monorepo-base-config/test/base.test.ts
+++ b/samples/monorepo-base-config/test/base.test.ts
@@ -1,0 +1,5 @@
+import { expect, it } from 'vitest'
+
+it('runs with the base config', () => {
+  expect(1).toBe(1)
+})

--- a/samples/monorepo-base-config/vitest.config.base.ts
+++ b/samples/monorepo-base-config/vitest.config.base.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+// shared base config - defines NO tags, they only live in the package config
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/test/e2e/runner.test.ts
+++ b/test/e2e/runner.test.ts
@@ -88,6 +88,43 @@ test('workspaces', async ({ launch }) => {
   await expect(tester.tree.getResultsLocator()).toHaveText('4/4')
 })
 
+test('the closest config provides the default profile when a base config claims the same test files', async ({
+  launch,
+}) => {
+  const { page, tester } = await launch({
+    workspacePath: './samples/monorepo-base-config',
+  })
+
+  // expanding both folders guarantees both Vitest instances finished discovery,
+  // so the shared file item is already tagged by the closest config
+  await tester.tree.expand('packages/foo/test')
+  await tester.tree.expand('test')
+
+  const taggedTests = tester.tree.getFileItem('tagged.test.ts')
+  const baseTests = tester.tree.getFileItem('base.test.ts')
+
+  await expect(taggedTests.locator).toBeVisible()
+  await expect(baseTests.locator).toBeVisible()
+
+  // run the first test from the editor gutter: VSCode resolves this "ambiguous"
+  // run to the first default profile whose tag matches the test item - it must be
+  // packages/foo/vitest.config.ts (which defines the "integration" tag), not the
+  // root vitest.config.base.ts instance, which fails with "The Vitest config
+  // doesn't define any tags"
+  await taggedTests.navigate()
+  const gutterRunButton = page.locator('.testing-run-glyph').first()
+  await expect(gutterRunButton).toBeVisible()
+  await gutterRunButton.click()
+
+  await expect(tester.tree.getResultsLocator()).toHaveText('1/1')
+
+  // the base config instance still runs its own tests
+  await baseTests.run()
+
+  await expect(tester.tree.getResultsLocator()).toHaveText('1/1')
+  await expect(baseTests).toHaveState('passed')
+})
+
 test('running a project does not update other projects', async ({ launch }) => {
   const { tester } = await launch({
     workspacePath: './samples/projects',

--- a/test/unit/configOwnership.test.ts
+++ b/test/unit/configOwnership.test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai'
+import { getConfigSpecificity, isCloserConfig } from '../../packages/extension/src/configOwnership'
+
+describe('config ownership', () => {
+  const testFile = '/repo/packages/foo/test/tags.test.ts'
+
+  it('prefers the config defined closest to the test file', () => {
+    expect(
+      isCloserConfig(
+        '/repo/packages/foo/vitest.config.ts',
+        '/repo/vitest.config.base.ts',
+        testFile,
+      ),
+    ).to.equal(true)
+    expect(
+      isCloserConfig(
+        '/repo/vitest.config.base.ts',
+        '/repo/packages/foo/vitest.config.ts',
+        testFile,
+      ),
+    ).to.equal(false)
+  })
+
+  it('keeps the current owner when both configs are in the same folder', () => {
+    expect(
+      isCloserConfig(
+        '/repo/packages/foo/vitest.e2e.config.ts',
+        '/repo/packages/foo/vitest.unit.config.ts',
+        testFile,
+      ),
+    ).to.equal(false)
+  })
+
+  it('never reassigns to a config that does not contain the test file', () => {
+    expect(
+      isCloserConfig('/repo/packages/bar/vitest.config.ts', '/repo/vitest.config.ts', testFile),
+    ).to.equal(false)
+    expect(
+      isCloserConfig(
+        '/repo/packages/foo/vitest.config.ts',
+        '/repo/packages/bar/vitest.config.ts',
+        testFile,
+      ),
+    ).to.equal(true)
+  })
+
+  it('scores configs that do not contain the test file with -1', () => {
+    expect(getConfigSpecificity('/repo/packages/bar/vitest.config.ts', testFile)).to.equal(-1)
+    expect(getConfigSpecificity(undefined, testFile)).to.equal(-1)
+  })
+
+  it('scores deeper configs higher', () => {
+    const base = getConfigSpecificity('/repo/vitest.config.base.ts', testFile)
+    const pkg = getConfigSpecificity('/repo/packages/foo/vitest.config.ts', testFile)
+    expect(base).to.be.greaterThan(-1)
+    expect(pkg).to.be.greaterThan(base)
+  })
+})


### PR DESCRIPTION
### Description

Fixes #799.

When a repository contains a shared base config such as `vitest.config.base.ts`, the config discovery glob (`**/*{vite,vitest}*.config*.{ts,js,mjs,cjs,cts,mts}`) matches it and the extension spawns a Vitest instance for it. That instance is rooted at the repository root, so its default `include` claims the same test files as the package-level configs that extend the base config.

File test items are keyed by `file path + project name`. For standalone configs the project name is empty, so both instances resolve to the same test item, and the item keeps the tag of whichever instance resolves it first. Configs resolve shallowest-first, so that is always the base config. VSCode resolves ambiguous runs (editor gutter, tree run button) through the item's tag — [`canUseProfileWithTest`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/testing/common/testProfileService.ts) requires `test.item.tags.includes(profile.tag)` — so those runs always went to the base-config instance and failed on anything only the leaf config defines. With Vitest 4.1 test tags this surfaces as:

```
Error: The Vitest config does't define any "tags", cannot apply "tulipindicators" tag for this test.
```

### Fix: the closest config tags the shared test item

`TestTree.retagFileItemIfCloser`: when an instance claims a file item that another instance already tagged, the instance whose config file is defined closest to the test file tags the item (`configOwnership.ts`). Ambiguous runs then resolve to the most specific config — the one that carries the complete merged configuration for that file.

This deliberately does **not** dedupe anything (per the [review feedback](https://github.com/vitest-dev/vscode/issues/799#issuecomment-5166945687) that configs define what test files they include, not the other way around):

- Every instance still discovers and runs the file in its own full runs and watch mode.
- All profiles stay registered and can be picked explicitly via "Execute Using Profile...".
- Only the *default* resolution for ambiguous runs changes, matching "we just provide the default; if you have a custom setup, configure it".
- Ties (e.g. `vitest.unit.config.ts` + `vitest.e2e.config.ts` in the same folder) keep the current behavior. Named projects never collide (their items are keyed per project) and are unaffected.

### Why not profile registration order

[The suggestion in #799](https://github.com/vitest-dev/vscode/issues/799#issuecomment-5190220823) to register profiles in a different order so "vscode picks up the earliest automatically" unfortunately doesn't work: VSCode re-sorts profiles on every registration by `isDefault` and then `label.localeCompare` ([testProfileService.ts, `addProfile`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/testing/common/testProfileService.ts)), so registration order never reaches the selection in `getDefaultProfileForTest`. The item's tag is the only lever the extension controls — which also means no registration needs to be delayed, so there's no initialisation cost for nested configs.

### Validation

- New e2e test (`the closest config provides the default profile when a base config claims the same test files`) with a `samples/monorepo-base-config` sample mirroring the structure from #799 (`vitest.config.base.ts` at the root + `packages/foo/vitest.config.ts` adding `tags` via `mergeConfig`). It runs the tagged test through the **editor gutter** — the ambiguous-run path where the bug lives. On `main` this fails with the exact error from #799.
- New unit tests for the specificity scoring (`test/unit/configOwnership.test.ts`).
- `pnpm typecheck` and `pnpm fmt` pass locally.

### Notes

- The reproduction sample added in #800 cannot reproduce the issue: it defines the `tags` in the same config that the extension discovers, which works fine. The new sample uses the base-config structure that actually triggers the bug.
- Full runs of the base-config instance ("Run Tests" toolbar) still execute tagged files through the base config and fail there — that is the documented model (a config runs everything it includes) and is what "Toggle Configs" is for. This PR only fixes which profile an ambiguous run resolves to.
- Unrelated local finding: `@vscode/test-electron` cannot launch current VS Code stable on macOS because the app binary was renamed from `Electron` to `Code` in 1.132. Pinning an older build works around it.
