### PR TITLE
feat: support Vitest 5 testNamePattern format

### DIFF
--- a/packages/extension/src/apiProcess.ts
+++ b/packages/extension/src/apiProcess.ts
@@ -1,5 +1,6 @@
 import type { SerializedProject } from 'vitest-vscode-shared'
 import type { VitestPackage } from './spawn/pkg'
+import { usesJestTestNamePattern } from './spawn/pkg'
 import type { ExtensionWorkerEvents, VitestExtensionRPC } from './spawn/rpc'
 import type { ExtensionWorkerProcess } from './spawn/types'
 import type { ProcessSpawnOptions } from './spawn/ws'
@@ -43,6 +44,10 @@ export class VitestProjectConfig {
 
   get version() {
     return this.pkg.version
+  }
+
+  get usesJestTestNamePattern() {
+    return usesJestTestNamePattern(this.pkg)
   }
 
   get package() {
@@ -140,6 +145,10 @@ export class VitestProcessAPI {
 
   get package() {
     return this.config.package
+  }
+
+  get usesJestTestNamePattern() {
+    return this.config.usesJestTestNamePattern
   }
 
   getPersistentProcessMeta() {

--- a/packages/extension/src/spawn/pkg.ts
+++ b/packages/extension/src/spawn/pkg.ts
@@ -30,6 +30,15 @@ export interface VitestPackage {
   runtime: 'deno' | 'node'
 }
 
+// Before 5.0.0-rc.1 `testNamePattern` was matched the same way Jest does it:
+// against task names joined with " ", starting with the empty name of the root suite.
+// Since 5.0.0-rc.1 the pattern is tested against names joined with " > " instead.
+// If the version is not known yet ("pnp"), it is updated from the "ready"
+// event when the worker reports the actual runtime version.
+export function usesJestTestNamePattern(pkg: VitestPackage): boolean {
+  return pkg.version === 'pnp' || !gte(pkg.version, '5.0.0-rc.1')
+}
+
 function isVitestInPackageJson(root: string) {
   const pkgJson = resolve(dirname(root), 'package.json')
   if (existsSync(pkgJson)) {

--- a/packages/extension/src/spawn/ws.ts
+++ b/packages/extension/src/spawn/ws.ts
@@ -81,6 +81,11 @@ export function onWsConnection(
     if (message.type === 'debug') log.worker('info', ...message.args)
 
     if (message.type === 'ready') {
+      // the worker reports the version it actually runs; "pkg.version" can be
+      // a "pnp" placeholder when the package.json is not readable from the fs
+      if (message.version) {
+        pkg.version = message.version
+      }
       const { api, handlers } = createVitestRpc({
         on: (listener) => ws.on('message', listener),
         send: (message) => ws.send(message),

--- a/packages/extension/src/testTree.ts
+++ b/packages/extension/src/testTree.ts
@@ -394,7 +394,9 @@ export class TestTree extends vscode.Disposable {
           ids.add(fileId)
         })
       } else if (task.each) {
-        const fullName = getTaskFullName(task)
+        // the separator has to match the one used in getTestNamePattern
+        const separator = fileData.api.usesJestTestNamePattern ? ' ' : ' > '
+        const fullName = getTaskFullName(task, separator)
         // order in the opposite order so we only match one item with the longest name
         const orderedTests = Object.entries(fileCachedTests).sort(([a1], [a2]) =>
           a2.localeCompare(a1),
@@ -491,6 +493,6 @@ function getAPIFromTestItem(testItem: vscode.TestItem): VitestProcessAPI | null 
   return data.file.api
 }
 
-function getTaskFullName(task: RunnerTask): string {
-  return `${task.suite ? `${getTaskFullName(task.suite)} ` : ''}${task.name}`
+function getTaskFullName(task: RunnerTask, separator: string): string {
+  return `${task.suite ? `${getTaskFullName(task.suite, separator)}${separator}` : ''}${task.name}`
 }

--- a/packages/extension/src/testTreeData.ts
+++ b/packages/extension/src/testTreeData.ts
@@ -82,7 +82,7 @@ export class TestFile extends BaseTestData {
 
 class TaskName {
   constructor(
-    private readonly data: TestData,
+    private readonly data: TestCase | TestSuite,
     public readonly dynamic: boolean,
   ) {}
 
@@ -99,9 +99,13 @@ class TaskName {
       patterns.push(escapeTestName(iter.label, iter.name.dynamic))
       iter = iter.parent
     }
-    // vitest's test task name starts with ' ' of root suite
-    // It's considered as a bug, but it's not fixed yet for backward compatibility
-    return `\\s?${patterns.reverse().join(' ')}`
+    if (this.data.file.api.usesJestTestNamePattern) {
+      // vitest's test task name starts with ' ' of root suite
+      // It's considered as a bug, but it's not fixed until Vitest 5 for backward compatibility
+      return `\\s?${patterns.reverse().join(' ')}`
+    }
+    // since 5.0.0-rc.1 the pattern is matched against names joined with " > "
+    return patterns.reverse().join(' > ')
   }
 }
 

--- a/packages/extension/src/worker/index.ts
+++ b/packages/extension/src/worker/index.ts
@@ -73,7 +73,7 @@ emitter.on('message', async function onMessage(message: any) {
       })
       worker.initRpc(rpc)
       reporter.initRpc(rpc)
-      emitter.ready(projects, workspaceSource, isLegacy)
+      emitter.ready(projects, workspaceSource, isLegacy, vitestModule.version)
 
       await worker.vitest.report('onInit', worker.vitest)
     } catch (err: any) {

--- a/packages/shared/src/emitter.ts
+++ b/packages/shared/src/emitter.ts
@@ -8,8 +8,13 @@ abstract class WorkerEventEmitter {
   abstract on(event: string, listener: (...args: any[]) => void): void
   abstract off(event: string, listener: (...args: any[]) => void): void
 
-  ready(projects: SerializedProject[], workspaceSource: string | false, legacy: boolean) {
-    this.sendWorkerEvent({ type: 'ready', projects, workspaceSource, legacy })
+  ready(
+    projects: SerializedProject[],
+    workspaceSource: string | false,
+    legacy: boolean,
+    version: string | undefined,
+  ) {
+    this.sendWorkerEvent({ type: 'ready', projects, workspaceSource, legacy, version })
   }
 
   error(err: any) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -194,6 +194,9 @@ export interface EventReady {
   projects: SerializedProject[]
   workspaceSource: string | false
   legacy: boolean
+  // the actual runtime version, unlike VitestPackage.version
+  // this is also defined when vitest is resolved via yarn pnp
+  version: string | undefined
 }
 
 export interface EventDebug {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: ^0.0.6
       version: 0.0.6
     '@vscode/test-electron':
-      specifier: ^2.3.9
-      version: 2.5.2
+      specifier: ^3.1.0
+      version: 3.1.0
     '@vscode/vsce':
       specifier: ^3.1.0
       version: 3.7.1
@@ -195,7 +195,7 @@ importers:
         version: 0.0.6
       '@vscode/test-electron':
         specifier: 'catalog:'
-        version: 2.5.2
+        version: 3.1.0
       '@vscode/vsce':
         specifier: 'catalog:'
         version: 3.7.1
@@ -1944,9 +1944,9 @@ packages:
     resolution: {integrity: sha512-4i61OUv5PQr3GxhHOuUgHdgBDfIO/kXTPCsEyFiMaY4SOqQTgkTmyZLagHehjOgCfsXdcrJa3zgQ7zoc+Dh6hQ==}
     hasBin: true
 
-  '@vscode/test-electron@2.5.2':
-    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
-    engines: {node: '>=16'}
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
+    engines: {node: '>=22'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
@@ -6220,7 +6220,7 @@ snapshots:
       supports-color: 9.4.0
       yargs: 17.7.2
 
-  '@vscode/test-electron@2.5.2':
+  '@vscode/test-electron@3.1.0':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   '@types/which': ^3.0.3
   '@types/ws': ^8.5.10
   '@vscode/test-cli': ^0.0.6
-  '@vscode/test-electron': ^2.3.9
+  '@vscode/test-electron': ^3.1.0
   '@vscode/vsce': ^3.1.0
   '@vue/reactivity': ^3.2.33
   acorn: ^8.12.0

--- a/test/e2e/utils/helper.ts
+++ b/test/e2e/utils/helper.ts
@@ -44,10 +44,13 @@ export const test = baseTest.extend<{ launch: LaunchFixture; taskName: string; l
       const trace = (options.trace ?? defaultConfig.VSCODE_E2E_TRACE) === 'on'
 
       const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'vscode-e2e-'))
+      // inherited from the extension host when tests run in a terminal inside
+      // VS Code; it would force the spawned VS Code to run as plain Node
+      const { ELECTRON_RUN_AS_NODE: _, ...env } = process.env
       const app = await _electron.launch({
         executablePath,
         env: {
-          ...process.env,
+          ...env,
           VITEST_VSCODE_E2E_LOG_FILE: logPath,
           VITEST_VSCODE_LOG: 'verbose',
         },

--- a/test/unit/TestData.test.ts
+++ b/test/unit/TestData.test.ts
@@ -11,51 +11,67 @@ import {
 
 describe('TestData', () => {
   const ctrl = vscode.tests.createTestController('mocha', 'Vitest')
+
+  function createTestTree(id: string, api: { usesJestTestNamePattern: boolean }) {
+    const filepath = path.resolve(__dirname, `./fixtures/discover/00_simple_${id}.ts`)
+    const uri = vscode.Uri.file(filepath)
+    const folderItem = ctrl.createTestItem(
+      path.dirname(filepath),
+      path.basename(path.dirname(filepath)),
+      uri,
+    )
+    TestFolder.register(folderItem)
+    const testItem = ctrl.createTestItem(filepath, path.basename(filepath), uri)
+    ctrl.items.add(testItem)
+    const file = TestFile.register(testItem, folderItem, filepath, api as any, {
+      project: '',
+      pool: 'trheads',
+    })
+    const suiteItem = ctrl.createTestItem(`${filepath}_1`, 'describe', uri)
+    testItem.children.add(suiteItem)
+
+    const testItem1 = ctrl.createTestItem(`${filepath}_1_1`, 'test', uri)
+
+    const testItem2 = ctrl.createTestItem(`${filepath}_1_2`, 'test 1', uri)
+
+    const testItem3 = ctrl.createTestItem(`${filepath}_1_3`, 'test 2', uri)
+
+    suiteItem.children.add(testItem1)
+    suiteItem.children.add(testItem2)
+    suiteItem.children.add(testItem3)
+
+    const suite = TestSuite.register(suiteItem, testItem, file, false)
+
+    const test1 = TestCase.register(testItem1, suiteItem, file, false)
+    const test2 = TestCase.register(testItem2, suiteItem, file, false)
+    const test3 = TestCase.register(testItem3, suiteItem, file, false)
+
+    expect(testItem1.parent).to.exist
+
+    return { suite, test1, test2, test3 }
+  }
+
   describe('TestFile', () => {
-    it('getTestNamePattern', async () => {
-      const filepath = path.resolve(__dirname, './fixtures/discover/00_simple.ts')
-      const uri = vscode.Uri.file(filepath)
-      const folderItem = ctrl.createTestItem(
-        path.dirname(filepath),
-        path.basename(path.dirname(filepath)),
-        uri,
-      )
-      TestFolder.register(folderItem)
-      const testItem = ctrl.createTestItem(filepath, path.basename(filepath), uri)
-      ctrl.items.add(testItem)
-      const file = TestFile.register(
-        testItem,
-        folderItem,
-        filepath,
-        null as any, // not used yet
-        { project: '', pool: 'trheads' },
-      )
-      const suiteItem = ctrl.createTestItem(`${filepath}_1`, 'describe', uri)
-      testItem.children.add(suiteItem)
-
-      const testItem1 = ctrl.createTestItem(`${filepath}_1_1`, 'test', uri)
-
-      const testItem2 = ctrl.createTestItem(`${filepath}_1_2`, 'test 1', uri)
-
-      const testItem3 = ctrl.createTestItem(`${filepath}_1_3`, 'test 2', uri)
-
-      suiteItem.children.add(testItem1)
-      suiteItem.children.add(testItem2)
-      suiteItem.children.add(testItem3)
-
-      const suite = TestSuite.register(suiteItem, testItem, file, false)
+    it('getTestNamePattern with jest pattern (vitest < 5)', async () => {
+      const { suite, test1, test2, test3 } = createTestTree('jest', {
+        usesJestTestNamePattern: true,
+      })
 
       expect(suite.getTestNamePattern()).to.equal('^\\s?describe')
-
-      const test1 = TestCase.register(testItem1, suiteItem, file, false)
-      const test2 = TestCase.register(testItem2, suiteItem, file, false)
-      const test3 = TestCase.register(testItem3, suiteItem, file, false)
-
-      expect(testItem1.parent).to.exist
-
       expect(test1.getTestNamePattern()).to.equal('^\\s?describe test$')
       expect(test2.getTestNamePattern()).to.equal('^\\s?describe test 1$')
       expect(test3.getTestNamePattern()).to.equal('^\\s?describe test 2$')
+    })
+
+    it('getTestNamePattern (vitest 5)', async () => {
+      const { suite, test1, test2, test3 } = createTestTree('vitest', {
+        usesJestTestNamePattern: false,
+      })
+
+      expect(suite.getTestNamePattern()).to.equal('^describe')
+      expect(test1.getTestNamePattern()).to.equal('^describe > test$')
+      expect(test2.getTestNamePattern()).to.equal('^describe > test 1$')
+      expect(test3.getTestNamePattern()).to.equal('^describe > test 2$')
     })
 
     it('throws an error if data was not set', () => {


### PR DESCRIPTION
## Description

Vitest 5.0.0-rc.1 changes how `testNamePattern` is matched: the pattern is now tested against `task.fullTestName` — task names joined with `' > '` — instead of the Jest-aligned format (names joined with `' '`, starting with the empty name of the root suite).

This PR builds the pattern based on the Vitest version, gated by a new `usesJestTestNamePattern(pkg)` helper (`true` below `5.0.0-rc.1`).
