### PR TITLE
fix: ignore computed member calls from esbuild `using` helper in legacy AST collector

### DIFF
--- a/packages/worker-legacy/src/collect.ts
+++ b/packages/worker-legacy/src/collect.ts
@@ -24,7 +24,7 @@ interface ParsedSuite extends RunnerTestSuite {
   dynamic: boolean
 }
 
-interface LocalCallDefinition {
+export interface LocalCallDefinition {
   start: number
   end: number
   name: string
@@ -96,6 +96,12 @@ export function astParseFile(filepath: string, code: string) {
       return getName(callee.tag)
     }
     if (callee.type === 'MemberExpression') {
+      // Vitest chains always use dot access (`test.skip`, `describe.each`).
+      // A computed access like `it[1].call(it[2])` comes from esbuild's
+      // `using` helper (`__callDispose`) and is not a Vitest call.
+      if (callee.computed) {
+        return null
+      }
       if (callee.object?.type === 'Identifier' && isVitestFunctionName(callee.object.name)) {
         return callee.object?.name
       }

--- a/test/unit/collect.test.ts
+++ b/test/unit/collect.test.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai'
+import { astParseFile, type LocalCallDefinition } from '../../packages/worker-legacy/src/collect'
+
+const sorted = (defs: LocalCallDefinition[]) => [...defs].sort((a, b) => a.start - b.start)
+
+describe('astParseFile', () => {
+  it('ignores esbuild "using" helper calls like it[1].call(it[2])', () => {
+    // simplified output of esbuild's `__callDispose` helper (target < esnext)
+    const code = `
+var __callDispose = (stack, error, hasError) => {
+  var next = (it) => {
+    while (it = stack.pop()) {
+      var result = it[1] && it[1].call(it[2]);
+    }
+  };
+  return next();
+};
+describe('suite', () => {
+  test('case', () => {
+    var _stack = [];
+    try {
+      const x = __using(_stack, 1);
+    } finally {
+      __callDispose(_stack, _error, _hasError);
+    }
+  });
+});
+`
+    const { definitions } = astParseFile('/test.ts', code)
+    expect(sorted(definitions).map((d) => [d.type, d.name])).to.eql([
+      ['suite', 'suite'],
+      ['test', 'case'],
+    ])
+  })
+
+  it('still collects dot-access chains', () => {
+    const code = `
+describe.concurrent('suite', () => {
+  test.skip('case', () => {})
+})
+`
+    const { definitions } = astParseFile('/test.ts', code)
+    expect(sorted(definitions).map((d) => [d.type, d.name, d.mode])).to.eql([
+      ['suite', 'suite', 'run'],
+      ['test', 'case', 'skip'],
+    ])
+  })
+})


### PR DESCRIPTION
Closes #804

When `esbuild.target` is below `esnext`, esbuild lowers `using` and injects a `__callDispose` helper that contains `it[1].call(it[2])`. The AST collector unwrapped `it[1].call` to the identifier `it`, which matches a test function name, and reported a phantom `it[2]` test.

`getName` now returns `null` for a computed `MemberExpression`. Vitest chains always use dot access (`test.skip`, `describe.each`), so a computed access is never a Vitest call.

Vitest 4 uses the parser inside Vitest itself; the same fix is submitted there separately.