### PR TITLE
refactor: group worker config metadata

### DIFF
--- a/packages/extension/src/api.ts
+++ b/packages/extension/src/api.ts
@@ -187,13 +187,13 @@ async function createVitestProcessAPI(
   pkg: VitestPackage,
 ): Promise<DiscoveryResult> {
   return withProcess(pkg, async (meta) => {
-    meta.config.projects.forEach((project) => {
+    meta.metadata.projects.forEach((project) => {
       if (project.config) {
         usedConfigs.add(project.config)
       }
     })
     const files = await meta.rpc.getFiles()
-    const config = new VitestProjectConfig(pkg, meta.config)
+    const config = new VitestProjectConfig(pkg, meta.metadata)
     const api = new VitestProcessAPI(config)
     return { api, files }
   })

--- a/packages/extension/src/api.ts
+++ b/packages/extension/src/api.ts
@@ -187,13 +187,13 @@ async function createVitestProcessAPI(
   pkg: VitestPackage,
 ): Promise<DiscoveryResult> {
   return withProcess(pkg, async (meta) => {
-    meta.projects.forEach((project) => {
+    meta.config.projects.forEach((project) => {
       if (project.config) {
         usedConfigs.add(project.config)
       }
     })
     const files = await meta.rpc.getFiles()
-    const config = new VitestProjectConfig(pkg, meta.projects, meta.workspaceSource)
+    const config = new VitestProjectConfig(pkg, meta.config)
     const api = new VitestProcessAPI(config)
     return { api, files }
   })

--- a/packages/extension/src/apiProcess.ts
+++ b/packages/extension/src/apiProcess.ts
@@ -1,4 +1,4 @@
-import type { SerializedProject } from 'vitest-vscode-shared'
+import type { ExtensionWorkerConfig, SerializedProject } from 'vitest-vscode-shared'
 import type { VitestPackage } from './spawn/pkg'
 import { usesJestTestNamePattern } from './spawn/pkg'
 import type { ExtensionWorkerEvents, VitestExtensionRPC } from './spawn/rpc'
@@ -22,8 +22,7 @@ export class VitestProjectConfig {
 
   constructor(
     readonly pkg: VitestPackage,
-    readonly projects: SerializedProject[],
-    readonly workspaceSource: string | false,
+    readonly extensionConfig: ExtensionWorkerConfig,
   ) {
     this.id = normalize(pkg.id)
     this.workspaceFolder = pkg.folder
@@ -40,6 +39,14 @@ export class VitestProjectConfig {
 
   get configs() {
     return this.projects.map((p) => p.config).filter((n) => n != null)
+  }
+
+  get projects(): SerializedProject[] {
+    return this.extensionConfig.projects
+  }
+
+  get workspaceSource() {
+    return this.extensionConfig.workspaceSource
   }
 
   get version() {
@@ -111,7 +118,7 @@ export class VitestProcessAPI {
    * a handle wrapping the existing process (without closing it).
    */
   static forDebug(pkg: VitestPackage, meta: ResolvedMeta): VitestProcessAPI {
-    const config = new VitestProjectConfig(pkg, meta.projects, meta.workspaceSource)
+    const config = new VitestProjectConfig(pkg, meta.config)
     const api = new VitestProcessAPI(config)
     api.currentMeta = meta
     return api
@@ -321,10 +328,9 @@ export interface RunHandlers {
 
 export interface ResolvedMeta {
   rpc: VitestExtensionRPC
+  config: ExtensionWorkerConfig
   process: ExtensionWorkerProcess
-  workspaceSource: string | false
   pkg: VitestPackage
-  projects: SerializedProject[]
   handlers: {
     onProcessLog: (listener: ExtensionWorkerEvents['onProcessLog']) => void
     onConsoleLog: (listener: ExtensionWorkerEvents['onConsoleLog']) => void

--- a/packages/extension/src/apiProcess.ts
+++ b/packages/extension/src/apiProcess.ts
@@ -1,4 +1,4 @@
-import type { ExtensionWorkerConfig, SerializedProject } from 'vitest-vscode-shared'
+import type { SerializedProject, WorkerReadyMetadata } from 'vitest-vscode-shared'
 import type { VitestPackage } from './spawn/pkg'
 import { usesJestTestNamePattern } from './spawn/pkg'
 import type { ExtensionWorkerEvents, VitestExtensionRPC } from './spawn/rpc'
@@ -22,7 +22,7 @@ export class VitestProjectConfig {
 
   constructor(
     readonly pkg: VitestPackage,
-    readonly extensionConfig: ExtensionWorkerConfig,
+    readonly metadata: WorkerReadyMetadata,
   ) {
     this.id = normalize(pkg.id)
     this.workspaceFolder = pkg.folder
@@ -42,11 +42,11 @@ export class VitestProjectConfig {
   }
 
   get projects(): SerializedProject[] {
-    return this.extensionConfig.projects
+    return this.metadata.projects
   }
 
   get workspaceSource() {
-    return this.extensionConfig.workspaceSource
+    return this.metadata.workspaceSource
   }
 
   get version() {
@@ -118,7 +118,7 @@ export class VitestProcessAPI {
    * a handle wrapping the existing process (without closing it).
    */
   static forDebug(pkg: VitestPackage, meta: ResolvedMeta): VitestProcessAPI {
-    const config = new VitestProjectConfig(pkg, meta.config)
+    const config = new VitestProjectConfig(pkg, meta.metadata)
     const api = new VitestProcessAPI(config)
     api.currentMeta = meta
     return api
@@ -328,7 +328,7 @@ export interface RunHandlers {
 
 export interface ResolvedMeta {
   rpc: VitestExtensionRPC
-  config: ExtensionWorkerConfig
+  metadata: WorkerReadyMetadata
   process: ExtensionWorkerProcess
   pkg: VitestPackage
   handlers: {

--- a/packages/extension/src/spawn/terminal.ts
+++ b/packages/extension/src/spawn/terminal.ts
@@ -93,11 +93,10 @@ export async function createVitestTerminalProcess(
   const vitestProcess = new ExtensionTerminalProcess(terminal, server, meta.ws)
   return {
     rpc: meta.rpc,
+    config: meta.config,
     handlers: meta.handlers,
     pkg,
-    workspaceSource: meta.workspaceSource,
     process: vitestProcess,
-    projects: meta.projects,
     dispose: meta.dispose,
   }
 }

--- a/packages/extension/src/spawn/terminal.ts
+++ b/packages/extension/src/spawn/terminal.ts
@@ -93,7 +93,7 @@ export async function createVitestTerminalProcess(
   const vitestProcess = new ExtensionTerminalProcess(terminal, server, meta.ws)
   return {
     rpc: meta.rpc,
-    config: meta.config,
+    metadata: meta.metadata,
     handlers: meta.handlers,
     pkg,
     process: vitestProcess,

--- a/packages/extension/src/spawn/ws.ts
+++ b/packages/extension/src/spawn/ws.ts
@@ -114,14 +114,16 @@ export function onWsConnection(
       }
       onStart({
         rpc: api,
-        workspaceSource: message.workspaceSource,
+        config: {
+          ...message.config,
+          projects: message.config.projects.map((p) => {
+            if (p.dir) {
+              p.dir = resolve(pkg.cwd, p.dir)
+            }
+            return p
+          }),
+        },
         handlers,
-        projects: message.projects.map((p) => {
-          if (p.dir) {
-            p.dir = resolve(pkg.cwd, p.dir)
-          }
-          return p
-        }),
         ws,
         pkg,
         async dispose() {

--- a/packages/extension/src/spawn/ws.ts
+++ b/packages/extension/src/spawn/ws.ts
@@ -114,9 +114,9 @@ export function onWsConnection(
       }
       onStart({
         rpc: api,
-        config: {
-          ...message.config,
-          projects: message.config.projects.map((p) => {
+        metadata: {
+          ...message.metadata,
+          projects: message.metadata.projects.map((p) => {
             if (p.dir) {
               p.dir = resolve(pkg.cwd, p.dir)
             }

--- a/packages/extension/src/worker/index.ts
+++ b/packages/extension/src/worker/index.ts
@@ -39,7 +39,7 @@ emitter.on('message', async function onMessage(message: any) {
       const workerPath = pathToFileURL(join(__dirname, workerName))
       const initModule = await import(workerPath.toString())
 
-      const { createWorker, reporter, projects, workspaceSource } = await initModule.initVitest(
+      const { config, createWorker, reporter } = await initModule.initVitest(
         vitestModule,
         data,
         emitter,
@@ -73,7 +73,7 @@ emitter.on('message', async function onMessage(message: any) {
       })
       worker.initRpc(rpc)
       reporter.initRpc(rpc)
-      emitter.ready(projects, workspaceSource, isLegacy, vitestModule.version)
+      emitter.ready(config, isLegacy, vitestModule.version)
 
       await worker.vitest.report('onInit', worker.vitest)
     } catch (err: any) {

--- a/packages/extension/src/worker/index.ts
+++ b/packages/extension/src/worker/index.ts
@@ -39,7 +39,7 @@ emitter.on('message', async function onMessage(message: any) {
       const workerPath = pathToFileURL(join(__dirname, workerName))
       const initModule = await import(workerPath.toString())
 
-      const { config, createWorker, reporter } = await initModule.initVitest(
+      const { createWorker, metadata, reporter } = await initModule.initVitest(
         vitestModule,
         data,
         emitter,
@@ -73,7 +73,7 @@ emitter.on('message', async function onMessage(message: any) {
       })
       worker.initRpc(rpc)
       reporter.initRpc(rpc)
-      emitter.ready(config, isLegacy, vitestModule.version)
+      emitter.ready(metadata, isLegacy, vitestModule.version)
 
       await worker.vitest.report('onInit', worker.vitest)
     } catch (err: any) {

--- a/packages/shared/src/emitter.ts
+++ b/packages/shared/src/emitter.ts
@@ -1,4 +1,4 @@
-import type { ExtensionWorkerConfig, WorkerEvent } from 'vitest-vscode-shared'
+import type { WorkerEvent, WorkerReadyMetadata } from 'vitest-vscode-shared'
 import type WebSocket from 'ws'
 
 abstract class WorkerEventEmitter {
@@ -8,8 +8,8 @@ abstract class WorkerEventEmitter {
   abstract on(event: string, listener: (...args: any[]) => void): void
   abstract off(event: string, listener: (...args: any[]) => void): void
 
-  ready(config: ExtensionWorkerConfig, legacy: boolean, version: string | undefined) {
-    this.sendWorkerEvent({ type: 'ready', config, legacy, version })
+  ready(metadata: WorkerReadyMetadata, legacy: boolean, version: string | undefined) {
+    this.sendWorkerEvent({ type: 'ready', metadata, legacy, version })
   }
 
   error(err: any) {

--- a/packages/shared/src/emitter.ts
+++ b/packages/shared/src/emitter.ts
@@ -1,4 +1,4 @@
-import type { SerializedProject, WorkerEvent } from 'vitest-vscode-shared'
+import type { ExtensionWorkerConfig, WorkerEvent } from 'vitest-vscode-shared'
 import type WebSocket from 'ws'
 
 abstract class WorkerEventEmitter {
@@ -8,13 +8,8 @@ abstract class WorkerEventEmitter {
   abstract on(event: string, listener: (...args: any[]) => void): void
   abstract off(event: string, listener: (...args: any[]) => void): void
 
-  ready(
-    projects: SerializedProject[],
-    workspaceSource: string | false,
-    legacy: boolean,
-    version: string | undefined,
-  ) {
-    this.sendWorkerEvent({ type: 'ready', projects, workspaceSource, legacy, version })
+  ready(config: ExtensionWorkerConfig, legacy: boolean, version: string | undefined) {
+    this.sendWorkerEvent({ type: 'ready', config, legacy, version })
   }
 
   error(err: any) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -189,14 +189,14 @@ export interface SerializedProject {
   }
 }
 
-export interface ExtensionWorkerConfig {
+export interface WorkerReadyMetadata {
   projects: SerializedProject[]
   workspaceSource: string | false
 }
 
 export interface EventReady {
   type: 'ready'
-  config: ExtensionWorkerConfig
+  metadata: WorkerReadyMetadata
   legacy: boolean
   // the actual runtime version, unlike VitestPackage.version
   // this is also defined when vitest is resolved via yarn pnp

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -189,10 +189,14 @@ export interface SerializedProject {
   }
 }
 
-export interface EventReady {
-  type: 'ready'
+export interface ExtensionWorkerConfig {
   projects: SerializedProject[]
   workspaceSource: string | false
+}
+
+export interface EventReady {
+  type: 'ready'
+  config: ExtensionWorkerConfig
   legacy: boolean
   // the actual runtime version, unlike VitestPackage.version
   // this is also defined when vitest is resolved via yarn pnp

--- a/packages/worker-legacy/src/index.ts
+++ b/packages/worker-legacy/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  ExtensionWorkerConfig,
   SerializedProject,
   WorkerRunnerOptions,
   WorkerWSEventEmitter,
@@ -202,11 +203,11 @@ export async function initVitest(
     : vitest.config.workspace != null || vitest.config.projects != null
       ? vitest.server.config.configFile || false
       : false
+  const config: ExtensionWorkerConfig = { projects, workspaceSource }
   return {
     vitest,
     reporter,
-    workspaceSource,
-    projects,
+    config,
     meta,
     createWorker() {
       return new ExtensionWorker(vitest, !!data.debug, emitter)

--- a/packages/worker-legacy/src/index.ts
+++ b/packages/worker-legacy/src/index.ts
@@ -1,6 +1,6 @@
 import type {
-  ExtensionWorkerConfig,
   SerializedProject,
+  WorkerReadyMetadata,
   WorkerRunnerOptions,
   WorkerWSEventEmitter,
 } from 'vitest-vscode-shared'
@@ -203,11 +203,11 @@ export async function initVitest(
     : vitest.config.workspace != null || vitest.config.projects != null
       ? vitest.server.config.configFile || false
       : false
-  const config: ExtensionWorkerConfig = { projects, workspaceSource }
+  const metadata: WorkerReadyMetadata = { projects, workspaceSource }
   return {
     vitest,
     reporter,
-    config,
+    metadata,
     meta,
     createWorker() {
       return new ExtensionWorker(vitest, !!data.debug, emitter)

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  ExtensionWorkerConfig,
   SerializedProject,
   WorkerRunnerOptions,
   WorkerWSEventEmitter,
@@ -167,11 +168,11 @@ export async function initVitest(
 
   const workspaceSource: string | false =
     vitest.config.projects != null ? vitest.vite.config.configFile || false : false
+  const config: ExtensionWorkerConfig = { projects, workspaceSource }
   return {
     vitest,
     reporter,
-    workspaceSource,
-    projects,
+    config,
     meta,
     createWorker() {
       return new ExtensionWorker(vitest, !!data.debug, emitter)

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,6 +1,6 @@
 import type {
-  ExtensionWorkerConfig,
   SerializedProject,
+  WorkerReadyMetadata,
   WorkerRunnerOptions,
   WorkerWSEventEmitter,
 } from 'vitest-vscode-shared'
@@ -168,11 +168,11 @@ export async function initVitest(
 
   const workspaceSource: string | false =
     vitest.config.projects != null ? vitest.vite.config.configFile || false : false
-  const config: ExtensionWorkerConfig = { projects, workspaceSource }
+  const metadata: WorkerReadyMetadata = { projects, workspaceSource }
   return {
     vitest,
     reporter,
-    config,
+    metadata,
     meta,
     createWorker() {
       return new ExtensionWorker(vitest, !!data.debug, emitter)


### PR DESCRIPTION
- preliminary cleanup for https://github.com/vitest-dev/vscode/pull/811

This defines a bag of config-related data that is passed from Vitest worker to extension host as `ExtensionWorkerConfig`. This would make it simpler for https://github.com/vitest-dev/vscode/pull/811 to introduce one more value for html reporter path in the same bag.