### PR TITLE
ci: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: macos-latest


### PR DESCRIPTION
I just noticed each push in the same PR keeps running old CI runs. This PR adds same `concurrency` from vitest repo to prevent it.